### PR TITLE
Function to find secret chat id by user id

### DIFF
--- a/structures.c
+++ b/structures.c
@@ -2063,6 +2063,18 @@ int tgl_complete_peer_list (struct tgl_state *TLS, int index, const char *text, 
   }
 }
 
+int tgl_secret_chat_for_user (struct tgl_state *TLS, tgl_peer_id_t user_id) {
+    int index = 0;
+    while (index < TLS->peer_num && (tgl_get_peer_type (TLS->Peers[index]->id) != TGL_PEER_ENCR_CHAT || TLS->Peers[index]->encr_chat.user_id != tgl_get_peer_id (user_id) || TLS->Peers[index]->encr_chat.state != sc_ok)) {
+        index ++;
+    }
+    if (index < TLS->peer_num) {
+        return tgl_get_peer_id (TLS->Peers[index]->encr_chat.id);
+    } else {
+        return -1;
+    }
+}
+
 void tgls_free_peer_gw (tgl_peer_t *P, void *TLS) {
   tgls_free_peer (TLS, P);
 }

--- a/tgl.h
+++ b/tgl.h
@@ -227,6 +227,7 @@ int tgl_complete_user_list (struct tgl_state *TLS, int index, const char *text, 
 int tgl_complete_chat_list (struct tgl_state *TLS, int index, const char *text, int len, char **R);
 int tgl_complete_encr_chat_list (struct tgl_state *TLS, int index, const char *text, int len, char **R);
 int tgl_complete_peer_list (struct tgl_state *TLS, int index, const char *text, int len, char **R);
+int tgl_secret_chat_for_user (struct tgl_state *TLS, tgl_peer_id_t user_id);
 
 #define TGL_PEER_USER 1
 #define TGL_PEER_CHAT 2


### PR DESCRIPTION
Used to find the first active secret chat id given a user id. Return -1 if no active secret chat is found.
