### PR TITLE
Prevent segfault in remove_status_expire callback

### DIFF
--- a/structures.c
+++ b/structures.c
@@ -1840,6 +1840,7 @@ void tgls_free_user (struct tgl_state *TLS, struct tgl_user *U) {
   if (U->phone) { tfree_str (U->phone); }
   if (U->real_first_name) { tfree_str (U->real_first_name); }
   if (U->real_last_name) { tfree_str (U->real_last_name); }
+  if (U->status.ev) { tgl_remove_status_expire (TLS, U); }
   tgls_free_photo (TLS, &U->photo);
   tfree (U, sizeof (*U));
 }


### PR DESCRIPTION
I sometimes got a segfault after calling tgl_free_all,  because the status expiration timeout will still be called after that. After freeing that timer together with the user the segfaults disappeared.

Stacktrace: https://gist.github.com/majn/d20dc460022ceb07c67b