### PR TITLE
add support for deleting encripted chats

### DIFF
--- a/queries-encrypted.c
+++ b/queries-encrypted.c
@@ -210,6 +210,12 @@ void tgl_do_send_encr_msg_action (struct tgl_state *TLS, struct tgl_message *M, 
     out_int (CODE_decrypted_message_action_abort_key);
     out_long (M->action.exchange_id);
     break;
+  case tgl_message_action_delete_messages:
+    out_int (CODE_decrypted_message_action_delete_messages);
+    out_int(CODE_vector);
+    out_int(1);
+    out_long (M->id);
+    break;
   case tgl_message_action_noop:
     out_int (CODE_decrypted_message_action_noop);
     break;

--- a/queries.c
+++ b/queries.c
@@ -3096,6 +3096,13 @@ static struct query_methods delete_msg_methods = {
 };
 
 void tgl_do_delete_msg (struct tgl_state *TLS, long long id, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success), void *callback_extra) {
+  struct tgl_message *M = tgl_message_get (TLS, id);
+  if (tgl_get_peer_type (M->to_id) == TGL_PEER_ENCR_CHAT) {
+     M->action.type=tgl_message_action_delete_messages;
+     M->flags |=TGLMF_SERVICE;
+     tgl_do_send_msg (TLS, M, 0, 0);
+     return;
+  }
   clear_packet ();
   out_int (CODE_messages_delete_messages);
   out_int (CODE_vector);


### PR DESCRIPTION
Sends a `decryptedMessageActionDeleteMessages` service message on message deletion