### PR TITLE
Replace get_string with get_values

### DIFF
--- a/queries.c
+++ b/queries.c
@@ -1,4 +1,4 @@
-/* 
+/*
     This file is part of tgl-library
 
     This library is free software; you can redistribute it and/or
@@ -119,8 +119,8 @@ struct query *tglq_query_get (struct tgl_state *TLS, long long id) {
 static int alarm_query (struct tgl_state *TLS, struct query *q) {
   assert (q);
   vlogprintf (E_DEBUG - 2, "Alarm query %lld\n", q->msg_id);
-  
-  TLS->timer_methods->insert (q->ev, QUERY_TIMEOUT); 
+
+  TLS->timer_methods->insert (q->ev, QUERY_TIMEOUT);
 
   if (q->session && q->session_id && q->DC && q->DC->sessions[0] == q->session && q->session->session_id == q->session_id) {
     clear_packet ();
@@ -130,7 +130,7 @@ static int alarm_query (struct tgl_state *TLS, struct query *q) {
     out_int (q->seq_no);
     out_int (4 * q->data_len);
     out_ints (q->data, q->data_len);
-  
+
     tglmp_encrypt_send_message (TLS, q->session->c, packet_buffer, packet_ptr - packet_buffer, q->flags & QUERY_FORCE_SEND);
   } else {
     q->flags &= ~QUERY_ACK_RECEIVED;
@@ -152,7 +152,7 @@ void tglq_regen_query (struct tgl_state *TLS, long long id) {
   struct query *q = tglq_query_get (TLS, id);
   if (!q) { return; }
   q->flags &= ~QUERY_ACK_RECEIVED;
-  
+
   if (!(q->session && q->session_id && q->DC && q->DC->sessions[0] == q->session && q->session->session_id == q->session_id)) {
     q->session_id = 0;
   } else {
@@ -191,7 +191,7 @@ struct query *tglq_send_query_ex (struct tgl_state *TLS, struct tgl_dc *DC, int 
   memcpy (q->data, data, 4 * ints);
   q->msg_id = tglmp_encrypt_send_message (TLS, DC->sessions[0]->c, data, ints, 1 | (flags & QUERY_FORCE_SEND));
   q->session = DC->sessions[0];
-  q->seq_no = q->session->seq_no - 1; 
+  q->seq_no = q->session->seq_no - 1;
   q->session_id = q->session->session_id;
   if (!(DC->flags & 4) && !(flags & QUERY_FORCE_SEND)) {
     q->session_id = 0;
@@ -228,9 +228,9 @@ static int fail_on_error (struct tgl_state *TLS, struct query *q, int error_code
 
 void tglq_query_ack (struct tgl_state *TLS, long long id) {
   struct query *q = tglq_query_get (TLS, id);
-  if (q && !(q->flags & QUERY_ACK_RECEIVED)) { 
+  if (q && !(q->flags & QUERY_ACK_RECEIVED)) {
     assert (q->msg_id == id);
-    q->flags |= QUERY_ACK_RECEIVED; 
+    q->flags |= QUERY_ACK_RECEIVED;
     TLS->timer_methods->remove (q->ev);
   }
 }
@@ -298,7 +298,7 @@ int tglq_query_error (struct tgl_state *TLS, long long id) {
           offset = 13;
         }
         if (offset >= 0) {
-          int i = 0; 
+          int i = 0;
           while (offset < error_len && error[offset] >= '0' && error[offset] <= '9') {
             i = i * 10 + error[offset] - '0';
             offset ++;
@@ -315,7 +315,7 @@ int tglq_query_error (struct tgl_state *TLS, long long id) {
             TLS->timer_methods->insert (q->ev, 0);
             error_handled = 1;
             res = 1;
-          } 
+          }
         }
       }
       break;
@@ -331,7 +331,7 @@ int tglq_query_error (struct tgl_state *TLS, long long id) {
         }
         res = 1;
         error_handled = 1;
-      } 
+      }
       break;
     case 403:
       // privacy violation
@@ -339,7 +339,7 @@ int tglq_query_error (struct tgl_state *TLS, long long id) {
     case 404:
       // not found
       break;
-    case 420: 
+    case 420:
       // flood
     case 500:
       // internal error
@@ -360,7 +360,7 @@ int tglq_query_error (struct tgl_state *TLS, long long id) {
         struct tgl_dc *DC = q->DC;
         if (!(DC->flags & 4) && !(q->flags & QUERY_FORCE_SEND)) {
           q->session_id = 0;
-        }         
+        }
         error_handled = 1;
       }
       break;
@@ -383,7 +383,7 @@ int tglq_query_error (struct tgl_state *TLS, long long id) {
     if (res == -11) {
       TLS->active_queries --;
       return -1;
-      
+
     }
   }
   TLS->active_queries --;
@@ -450,7 +450,7 @@ int tglq_query_result (struct tgl_state *TLS, long long id) {
   }
   TLS->active_queries --;
   return 0;
-} 
+}
 
 static void out_random (int n) {
   assert (n <= 32);
@@ -475,7 +475,7 @@ void tgl_do_insert_header (struct tgl_state *TLS) {
     tsnprintf (buf, sizeof (buf) - 1, "%s (TGL %s)", TLS->app_version, TGL_VERSION);
     out_string (buf);
     out_string ("En");
-  } else { 
+  } else {
     out_string ("x86");
     out_string ("Linux");
     static char buf[4096];
@@ -488,7 +488,7 @@ void tgl_do_insert_header (struct tgl_state *TLS) {
 void tgl_set_query_error (struct tgl_state *TLS, int error_code, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
 void tgl_set_query_error (struct tgl_state *TLS, int error_code, const char *format, ...) {
   static char s[1001];
-  
+
   va_list ap;
   va_start (ap, format);
   vsnprintf (s, 1000, format, ap);
@@ -505,7 +505,7 @@ void tgl_set_query_error (struct tgl_state *TLS, int error_code, const char *for
 /* {{{ Default on error */
 
 static int q_void_on_error (struct tgl_state *TLS, struct query *q, int error_code, int error_len, const char *error) {
-  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error); 
+  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error);
   if (q->callback) {
     ((void (*)(struct tgl_state *,void *, int))(q->callback))(TLS, q->callback_extra, 0);
   }
@@ -513,7 +513,7 @@ static int q_void_on_error (struct tgl_state *TLS, struct query *q, int error_co
 }
 
 static int q_ptr_on_error (struct tgl_state *TLS, struct query *q, int error_code, int error_len, const char *error) {
-  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error); 
+  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error);
   if (q->callback) {
     ((void (*)(struct tgl_state *,void *, int, void *))(q->callback))(TLS, q->callback_extra, 0, NULL);
   }
@@ -521,7 +521,7 @@ static int q_ptr_on_error (struct tgl_state *TLS, struct query *q, int error_cod
 }
 
 static int q_list_on_error (struct tgl_state *TLS, struct query *q, int error_code, int error_len, const char *error) {
-  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error); 
+  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error);
   if (q->callback) {
     ((void (*)(struct tgl_state *,void *, int, int, void *))(q->callback))(TLS, q->callback_extra, 0, 0, NULL);
   }
@@ -544,7 +544,7 @@ static int help_get_config_on_answer (struct tgl_state *TLS, struct query *q, vo
   for (i = 0; i < DS_LVAL (DS_C->dc_options->cnt); i++) {
     fetch_dc_option (TLS, DS_C->dc_options->data[i]);
   }
-  
+
   int max_chat_size = DS_LVAL (DS_C->chat_size_max);
   int max_bcast_size = DS_LVAL (DS_C->broadcast_size_max);
   vlogprintf (E_DEBUG, "chat_size = %d, bcast_size = %d\n", max_chat_size, max_bcast_size);
@@ -562,14 +562,14 @@ static struct query_methods help_get_config_methods  = {
 };
 
 void tgl_do_help_get_config (struct tgl_state *TLS, void (*callback)(struct tgl_state *,void *, int), void *callback_extra) {
-  clear_packet ();  
+  clear_packet ();
   tgl_do_insert_header (TLS);
   out_int (CODE_help_get_config);
   tglq_send_query (TLS, TLS->DC_working, packet_ptr - packet_buffer, packet_buffer, &help_get_config_methods, 0, callback, callback_extra);
 }
 
 void tgl_do_help_get_config_dc (struct tgl_state *TLS, struct tgl_dc *D, void (*callback)(struct tgl_state *, void *, int), void *callback_extra) {
-  clear_packet ();  
+  clear_packet ();
   tgl_do_insert_header (TLS);
   out_int (CODE_help_get_config);
   tglq_send_query_ex (TLS, D, packet_ptr - packet_buffer, packet_buffer, &help_get_config_methods, 0, callback, callback_extra, 2);
@@ -580,9 +580,9 @@ void tgl_do_help_get_config_dc (struct tgl_state *TLS, struct tgl_dc *D, void (*
 static int send_code_on_answer (struct tgl_state *TLS, struct query *q, void *D) {
   struct tl_ds_auth_sent_code *DS_ASC = D;
 
-  char *phone_code_hash = DS_STR_DUP (DS_ASC->phone_code_hash); 
+  char *phone_code_hash = DS_STR_DUP (DS_ASC->phone_code_hash);
   int registered = DS_BVAL (DS_ASC->phone_registered);;
-  
+
   if (q->callback) {
     ((void (*)(struct tgl_state *, void *, int, int, const char *))(q->callback)) (TLS, q->callback_extra, 1, registered, phone_code_hash);
   }
@@ -598,7 +598,7 @@ static struct query_methods send_code_methods  = {
 
 void tgl_do_send_code (struct tgl_state *TLS, const char *phone, int phone_len, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, int registered, const char *hash), void *callback_extra) {
   vlogprintf (E_DEBUG, "sending code to dc %d\n", TLS->dc_working_num);
-  
+
   clear_packet ();
   tgl_do_insert_header (TLS);
   out_int (CODE_auth_send_code);
@@ -627,7 +627,7 @@ static struct query_methods phone_call_methods  = {
 
 void tgl_do_phone_call (struct tgl_state *TLS, const char *phone, int phone_len, const char *hash, int hash_len, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success), void *callback_extra) {
   vlogprintf (E_DEBUG, "calling user\n");
-  
+
   clear_packet ();
   tgl_do_insert_header (TLS);
   out_int (CODE_auth_send_call);
@@ -644,7 +644,7 @@ static int sign_in_on_answer (struct tgl_state *TLS, struct query *q, void *D) {
   //vlogprintf (E_DEBUG, "Expires in %d\n", DS_LVAL (DS_AA->expires));
 
   struct tgl_user *U = tglf_fetch_alloc_user_new (TLS, DS_AA->user);
-  
+
   bl_do_dc_signed (TLS, TLS->DC_working->id);
 
   if (q->callback) {
@@ -655,7 +655,7 @@ static int sign_in_on_answer (struct tgl_state *TLS, struct query *q, void *D) {
 }
 
 static int sign_in_on_error (struct tgl_state *TLS, struct query *q, int error_code, int error_len, const char *error) {
-  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error); 
+  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error);
   if (q->callback) {
     ((void (*)(struct tgl_state *, void *, int, struct tgl_user *))q->callback) (TLS, q->callback_extra, 0, NULL);
   }
@@ -714,9 +714,9 @@ static int get_contacts_on_answer (struct tgl_state *TLS, struct query *q, void 
     list[i] = tglf_fetch_alloc_user_new (TLS, DS_CC->users->data[i]);
   }
   if (q->callback) {
-    ((void (*)(struct tgl_state *TLS, void *, int, int, struct tgl_user **))q->callback) (TLS, q->callback_extra, 1, n, list);  
+    ((void (*)(struct tgl_state *TLS, void *, int, int, struct tgl_user **))q->callback) (TLS, q->callback_extra, 1, n, list);
   }
-  tfree (list, sizeof (void *) * n); 
+  tfree (list, sizeof (void *) * n);
   return 0;
 }
 
@@ -738,19 +738,19 @@ void tgl_do_update_contact_list (struct tgl_state *TLS, void (*callback) (struct
 /* {{{ Send msg (plain text) */
 static int msg_send_on_answer (struct tgl_state *TLS, struct query *q, void *D) {
   struct tl_ds_messages_sent_message *DS_MSM = D;
-  
+
   long long y = *(long long *)q->extra;
   tfree (q->extra, 8);
-  
+
   struct tgl_message *M = tgl_message_get (TLS, y);
   vlogprintf (E_DEBUG, "y = %lld\n", y);
-  
+
   if (M && M->id != DS_LVAL (DS_MSM->id)) {
     assert (M->flags & TGLMF_PENDING);
-    bl_do_create_message_new (TLS, M->id, NULL, NULL, NULL, NULL, NULL, 
+    bl_do_create_message_new (TLS, M->id, NULL, NULL, NULL, NULL, NULL,
       DS_MSM->date, NULL, 0, DS_MSM->media, NULL, NULL, NULL, M->flags & 0xffff);
   }
- 
+
   struct tl_ds_update *UPD = talloc0 (sizeof (*UPD));
   UPD->magic = CODE_update_message_i_d;
   UPD->id = talloc (4);
@@ -771,7 +771,7 @@ static int msg_send_on_answer (struct tgl_state *TLS, struct query *q, void *D) 
 
   tglu_work_update_new (TLS, 1, UPD);
   tglu_work_update_new (TLS, 0, UPD);
-  
+
   free_ds_type_update (UPD, TYPE_TO_PARAM (update));
 
   y = tgls_get_local_by_random (TLS, y);
@@ -784,7 +784,7 @@ static int msg_send_on_answer (struct tgl_state *TLS, struct query *q, void *D) 
 }
 
 static int msg_send_on_error (struct tgl_state *TLS, struct query *q, int error_code, int error_len, const char *error) {
-  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error); 
+  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error);
   long long x = *(long long *)q->extra;
   tfree (q->extra, 8);
   struct tgl_message *M = tgl_message_get (TLS, x);
@@ -810,7 +810,7 @@ void tgl_do_send_msg (struct tgl_state *TLS, struct tgl_message *M, void (*callb
   }
   clear_packet ();
   out_int (CODE_messages_send_message);
-  
+
   out_int (((M->flags & TGLMF_DISABLE_PREVIEW) ? 2 : 0) | (M->reply_id ? 1 : 0) | (M->reply_markup ? 4 : 0));
   out_peer_id (TLS, M->to_id);
   if (M->reply_id) {
@@ -832,7 +832,7 @@ void tgl_do_send_msg (struct tgl_state *TLS, struct tgl_message *M, void (*callb
         out_int (CODE_keyboard_button_row);
         out_int (CODE_vector);
         out_int (M->reply_markup->row_start[i + 1] - M->reply_markup->row_start[i]);
-        int j; 
+        int j;
         for (j = 0; j < M->reply_markup->row_start[i + 1] - M->reply_markup->row_start[i]; j++) {
           out_int (CODE_keyboard_button);
           out_string (M->reply_markup->buttons[j + M->reply_markup->row_start[i]]);
@@ -1014,7 +1014,7 @@ static int mark_read_on_receive (struct tgl_state *TLS, struct query *q, void *D
 }
 
 static int mark_read_on_error (struct tgl_state *TLS, struct query *q, int error_code, int error_len, const char *error) {
-  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error); 
+  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error);
 
   struct mark_read_extra *E = q->extra;
   tfree (E, sizeof (*E));
@@ -1041,7 +1041,7 @@ void tgl_do_messages_mark_read (struct tgl_state *TLS, tgl_peer_id_t id, int max
   struct mark_read_extra *E = talloc (sizeof (*E));
   E->id = id;
   E->max_id = max_id;
-  
+
   tglq_send_query (TLS, TLS->DC_working, packet_ptr - packet_buffer, packet_buffer, &mark_read_methods, E, callback, callback_extra);
 }
 
@@ -1085,7 +1085,7 @@ static int get_history_on_answer (struct tgl_state *TLS, struct query *q, void *
   struct tl_ds_messages_messages *DS_MM = D;
 
   struct get_history_extra *E = q->extra;
-  
+
   int n = DS_LVAL (DS_MM->messages->cnt);
 
   if (E->list_size - E->list_offset < n) {
@@ -1097,7 +1097,7 @@ static int get_history_on_answer (struct tgl_state *TLS, struct query *q, void *
     assert (E->ML);
     E->list_size = new_list_size;
   }
-  
+
   int i;
   for (i = 0; i < n; i++) {
     E->ML[i + E->list_offset] = tglf_fetch_alloc_message_new (TLS, DS_MM->messages->data[i]);
@@ -1112,16 +1112,16 @@ static int get_history_on_answer (struct tgl_state *TLS, struct query *q, void *
     if (E->limit < 0) { E->limit = 0; }
   }
   assert (E->limit >= 0);
-  
+
   for (i = 0; i < DS_LVAL (DS_MM->chats->cnt); i++) {
     tglf_fetch_alloc_chat_new (TLS, DS_MM->chats->data[i]);
   }
-  
+
   for (i = 0; i < DS_LVAL (DS_MM->users->cnt); i++) {
     tglf_fetch_alloc_user_new (TLS, DS_MM->users->data[i]);
   }
 
- 
+
   if (E->limit <= 0 || DS_MM->magic == CODE_messages_messages) {
     if (q->callback) {
       ((void (*)(struct tgl_state *TLS, void *, int, int, struct tgl_message **))q->callback) (TLS, q->callback_extra, 1, E->list_offset, E->ML);
@@ -1129,7 +1129,7 @@ static int get_history_on_answer (struct tgl_state *TLS, struct query *q, void *
     if (E->list_offset > 0) {
       tgl_do_messages_mark_read (TLS, E->id, E->ML[0]->id, 0, 0, 0);
     }
-  
+
     tfree (E->ML, sizeof (void *) * E->list_size);
     tfree (E, sizeof (*E));
   } else {
@@ -1141,7 +1141,7 @@ static int get_history_on_answer (struct tgl_state *TLS, struct query *q, void *
 }
 
 static int get_history_on_error (struct tgl_state *TLS, struct query *q, int error_code, int error_len, const char *error) {
-  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error); 
+  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error);
 
   struct get_history_extra *E = q->extra;
   tfree (E->ML, sizeof (void *) * E->list_size);
@@ -1161,12 +1161,12 @@ static struct query_methods get_history_methods = {
 
 void tgl_do_get_local_history (struct tgl_state *TLS, tgl_peer_id_t id, int offset, int limit, void (*callback)(struct tgl_state *TLS,void *callback_extra, int success, int size, struct tgl_message *list[]), void *callback_extra) {
   tgl_peer_t *P = tgl_peer_get (TLS, id);
-  if (!P || !P->last) { 
+  if (!P || !P->last) {
     tgl_set_query_error (TLS, EINVAL, "unknown peer");
     if (callback) {
       callback (TLS, callback_extra, 0, 0, 0);
     }
-    return; 
+    return;
   }
   struct tgl_message *M = P->last;
   int count = 1;
@@ -1229,7 +1229,7 @@ struct get_dialogs_extra {
   int *UC;
   int *LM;
   int *LRM;
-  
+
   int list_offset;
   int list_size;
   int limit;
@@ -1251,7 +1251,7 @@ static int get_dialogs_on_answer (struct tgl_state *TLS, struct query *q, void *
     if (new_list_size < E->list_offset + dl_size) {
       new_list_size = E->list_offset + dl_size;
     }
-    
+
     E->PL = trealloc (E->PL, E->list_size * sizeof (tgl_peer_id_t), new_list_size * sizeof (tgl_peer_id_t));
     assert (E->PL);
     E->UC = trealloc (E->UC, E->list_size * sizeof (int), new_list_size * sizeof (int));
@@ -1260,7 +1260,7 @@ static int get_dialogs_on_answer (struct tgl_state *TLS, struct query *q, void *
     assert (E->LM);
     E->LRM = trealloc (E->LRM, E->list_size * sizeof (int), new_list_size * sizeof (int));
     assert (E->LRM);
-    
+
     E->list_size = new_list_size;
   }
 
@@ -1269,7 +1269,7 @@ static int get_dialogs_on_answer (struct tgl_state *TLS, struct query *q, void *
     struct tl_ds_dialog *DS_D = DS_MD->dialogs->data[i];
     E->PL[E->list_offset + i] = tglf_fetch_peer_id_new (TLS, DS_D->peer);
     E->LM[E->list_offset + i] = DS_LVAL (DS_D->top_message);
-    E->UC[E->list_offset + i] = DS_LVAL (DS_D->unread_count);    
+    E->UC[E->list_offset + i] = DS_LVAL (DS_D->unread_count);
     E->LRM[E->list_offset + i] = DS_LVAL (DS_D->read_inbox_max_id);
   }
   E->list_offset += dl_size;
@@ -1300,12 +1300,12 @@ static int get_dialogs_on_answer (struct tgl_state *TLS, struct query *q, void *
     tfree (E->LRM, 4 * E->list_size);
     tfree (E, sizeof (*E));
   }
-  
+
   return 0;
 }
 
 static int get_dialogs_on_error (struct tgl_state *TLS, struct query *q, int error_code, int error_len, const char *error) {
-  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error); 
+  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error);
 
   struct get_dialogs_extra *E = q->extra;
   tfree (E->PL, sizeof (tgl_peer_id_t) * E->list_size);
@@ -1384,9 +1384,9 @@ static int set_photo_on_answer (struct tgl_state *TLS, struct query *q, void *D)
 }
 
 static int send_file_part_on_error (struct tgl_state *TLS, struct query *q, int error_code, int error_len, const char *error) {
-  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error); 
+  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error);
 
-  struct send_file *f = q->extra;   
+  struct send_file *f = q->extra;
   tfree_str (f->file_name);
   tfree_str (f->caption);
   if (!f->avatar) {
@@ -1542,7 +1542,7 @@ static void send_file_unencrypted_end (struct tgl_state *TLS, struct send_file *
   struct messages_send_extra *E = talloc0 (sizeof (*E));
   tglt_secure_random (&E->id, 8);
   out_long (E->id);
-  
+
   tglq_send_query (TLS, TLS->DC_working, packet_ptr - packet_buffer, packet_buffer, &send_msgs_methods, E, callback, callback_extra);
   tfree_str (f->file_name);
   tfree_str (f->caption);
@@ -1553,7 +1553,7 @@ static void send_file_end (struct tgl_state *TLS, struct send_file *f, void *cal
   TLS->cur_uploaded_bytes -= f->size;
   TLS->cur_uploading_bytes -= f->size;
   clear_packet ();
-    
+
   if (f->avatar) {
     send_avatar_end (TLS, f, callback, callback_extra);
     return;
@@ -1573,11 +1573,11 @@ static void send_part (struct tgl_state *TLS, struct send_file *f, void *callbac
     }
     clear_packet ();
     if (f->size < (16 << 20)) {
-      out_int (CODE_upload_save_file_part);      
+      out_int (CODE_upload_save_file_part);
       out_long (f->id);
       out_int (f->part_num ++);
     } else {
-      out_int (CODE_upload_save_big_file_part);      
+      out_int (CODE_upload_save_big_file_part);
       out_long (f->id);
       out_int (f->part_num ++);
       out_int ((f->size + f->part_size - 1) / f->part_size);
@@ -1587,14 +1587,14 @@ static void send_part (struct tgl_state *TLS, struct send_file *f, void *callbac
     assert (x > 0);
     f->offset += x;
     TLS->cur_uploaded_bytes += x;
-    
+
     if (f->encr) {
       if (x & 15) {
         assert (f->offset == f->size);
         tglt_secure_random (buf + x, (-x) & 15);
         x = (x + 15) & ~15;
       }
-      
+
       AES_KEY aes_key;
       AES_set_encrypt_key (f->key, 256, &aes_key);
       AES_ige_encrypt ((void *)buf, (void *)buf, x, &aes_key, f->iv, 1);
@@ -1687,7 +1687,7 @@ static void _tgl_do_send_photo (struct tgl_state *TLS, tgl_peer_id_t to_id, cons
     }
     return;
   }
-  
+
   tglt_secure_random (&f->id, 8);
   f->to_id = to_id;
   f->flags = flags;
@@ -1706,7 +1706,7 @@ static void _tgl_do_send_photo (struct tgl_state *TLS, tgl_peer_id_t to_id, cons
     f->key = talloc (32);
     tglt_secure_random (f->key, 32);
   }
- 
+
   if (!f->encr && f->flags != -1 && thumb_len > 0) {
     send_file_thumb (TLS, f, thumb_data, thumb_len, callback, callback_extra);
   } else {
@@ -1747,7 +1747,7 @@ void tgl_do_reply_document (struct tgl_state *TLS, int reply_id, const char *fil
     id = M->from_id;
   }
 
-  tgl_do_send_document (TLS, id, file_name, caption, caption_len, flags | TGL_SEND_MSG_FLAG_REPLY (reply_id), callback, callback_extra); 
+  tgl_do_send_document (TLS, id, file_name, caption, caption_len, flags | TGL_SEND_MSG_FLAG_REPLY (reply_id), callback, callback_extra);
 }
 
 void tgl_do_set_chat_photo (struct tgl_state *TLS, tgl_peer_id_t chat_id, const char *file_name, void (*callback)(struct tgl_state *TLS,void *callback_extra, int success), void *callback_extra) {
@@ -1801,11 +1801,11 @@ int contact_search_on_answer (struct tgl_state *TLS, struct query *q, void *D) {
   struct tl_ds_user *DS_U = D;
 
   struct tgl_user *U = tglf_fetch_alloc_user_new (TLS, DS_U);
-  
+
   if (q->callback) {
     ((void (*)(struct tgl_state *,void *, int, struct tgl_user  *))q->callback) (TLS, q->callback_extra, 1, U);
   }
-  
+
   return 0;
 }
 
@@ -1829,7 +1829,7 @@ void tgl_do_contact_search (struct tgl_state *TLS, const char *name, int name_le
 static int send_msgs_on_answer (struct tgl_state *TLS, struct query *q, void *D) {
   tglu_work_any_updates_new (TLS, 1, D);
   tglu_work_any_updates_new (TLS, 0, D);
- 
+
   struct messages_send_extra *E = q->extra;
 
   if (!E) {
@@ -1850,7 +1850,7 @@ static int send_msgs_on_answer (struct tgl_state *TLS, struct query *q, void *D)
       ((void (*)(struct tgl_state *, void *, int, int, struct tgl_message **))q->callback) (TLS, q->callback_extra, 1, count, ML);
     }
     tfree (ML, sizeof (void *) * count);
-  } else { 
+  } else {
     int y = tgls_get_local_by_random (TLS, E->id);
     struct tgl_message *M = tgl_message_get (TLS, y);
     tfree (E, sizeof (*E));
@@ -1862,7 +1862,7 @@ static int send_msgs_on_answer (struct tgl_state *TLS, struct query *q, void *D)
 }
 
 static int send_msgs_on_error (struct tgl_state *TLS, struct query *q, int error_code, int error_len, const char *error) {
-  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error); 
+  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error);
   struct messages_send_extra *E = q->extra;
 
   if (!E) {
@@ -1876,7 +1876,7 @@ static int send_msgs_on_error (struct tgl_state *TLS, struct query *q, int error
     if (q->callback) {
       ((void (*)(struct tgl_state *, void *, int, int, struct tgl_message **))q->callback) (TLS, q->callback_extra, 0, 0, NULL);
     }
-  } else { 
+  } else {
     tfree (E, sizeof (*E));
     if (q->callback) {
       ((void (*)(struct tgl_state *, void *, int, struct tgl_message *))q->callback) (TLS, q->callback_extra, 0, NULL);
@@ -1893,7 +1893,7 @@ static struct query_methods send_msgs_methods = {
 
 void tgl_do_forward_messages (struct tgl_state *TLS, tgl_peer_id_t id, int n, const int ids[], unsigned long long flags, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, int count, struct tgl_message *ML[]), void *callback_extra) {
   if (tgl_get_peer_type (id) == TGL_PEER_ENCR_CHAT) {
-    tgl_set_query_error (TLS, EINVAL, "can not forward messages to secret chats"); 
+    tgl_set_query_error (TLS, EINVAL, "can not forward messages to secret chats");
     if (callback) {
       callback (TLS, callback_extra, 0, 0, 0);
     }
@@ -1925,7 +1925,7 @@ void tgl_do_forward_messages (struct tgl_state *TLS, tgl_peer_id_t id, int n, co
 
 void tgl_do_forward_message (struct tgl_state *TLS, tgl_peer_id_t id, int msg_id, unsigned long long flags, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, struct tgl_message *M), void *callback_extra) {
   if (tgl_get_peer_type (id) == TGL_PEER_ENCR_CHAT) {
-    tgl_set_query_error (TLS, EINVAL, "can not forward messages to secret chats"); 
+    tgl_set_query_error (TLS, EINVAL, "can not forward messages to secret chats");
     if (callback) {
       callback (TLS, callback_extra, 0, 0);
     }
@@ -1944,7 +1944,7 @@ void tgl_do_forward_message (struct tgl_state *TLS, tgl_peer_id_t id, int msg_id
 
 void tgl_do_send_contact (struct tgl_state *TLS, tgl_peer_id_t id, const char *phone, int phone_len, const char *first_name, int first_name_len, const char *last_name, int last_name_len, unsigned long long flags, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, struct tgl_message *M), void *callback_extra) {
   if (tgl_get_peer_type (id) == TGL_PEER_ENCR_CHAT) {
-    tgl_set_query_error (TLS, EINVAL, "can not send contact to secret chat"); 
+    tgl_set_query_error (TLS, EINVAL, "can not send contact to secret chat");
     if (callback) {
       callback (TLS, callback_extra, 0, 0);
     }
@@ -1962,7 +1962,7 @@ void tgl_do_send_contact (struct tgl_state *TLS, tgl_peer_id_t id, const char *p
   out_cstring (phone, phone_len);
   out_cstring (first_name, first_name_len);
   out_cstring (last_name, last_name_len);
-  
+
   struct messages_send_extra *E = talloc0 (sizeof (*E));
   tglt_secure_random (&E->id, 8);
   out_long (E->id);
@@ -1984,18 +1984,18 @@ void tgl_do_reply_contact (struct tgl_state *TLS, int reply_id, const char *phon
     }
     return;
   }
-  
+
   tgl_peer_id_t id = M->to_id;
   if (tgl_get_peer_type (id) == TGL_PEER_USER && tgl_get_peer_id (id) == TLS->our_id) {
     id = M->from_id;
   }
-  
+
   tgl_do_send_contact (TLS, id, phone, phone_len, first_name, first_name_len, last_name, last_name_len, flags | TGL_SEND_MSG_FLAG_REPLY (reply_id), callback, callback_extra);
 }
 
 void tgl_do_forward_media (struct tgl_state *TLS, tgl_peer_id_t id, int n, unsigned long long flags, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, struct tgl_message *M), void *callback_extra) {
   if (tgl_get_peer_type (id) == TGL_PEER_ENCR_CHAT) {
-    tgl_set_query_error (TLS, EINVAL, "can not forward messages to secret chats"); 
+    tgl_set_query_error (TLS, EINVAL, "can not forward messages to secret chats");
     if (callback) {
       callback (TLS, callback_extra, 0, 0);
     }
@@ -2041,7 +2041,7 @@ void tgl_do_forward_media (struct tgl_state *TLS, tgl_peer_id_t id, int n, unsig
   default:
     assert (0);
   }
-  
+
   struct messages_send_extra *E = talloc0 (sizeof (*E));
   tglt_secure_random (&E->id, 8);
   out_long (E->id);
@@ -2066,7 +2066,7 @@ void tgl_do_send_location (struct tgl_state *TLS, tgl_peer_id_t id, double latit
     out_int (CODE_input_geo_point);
     out_double (latitude);
     out_double (longitude);
-  
+
     struct messages_send_extra *E = talloc0 (sizeof (*E));
     tglt_secure_random (&E->id, 8);
     out_long (E->id);
@@ -2088,12 +2088,12 @@ void tgl_do_reply_location (struct tgl_state *TLS, int reply_id, double latitude
     }
     return;
   }
-  
+
   tgl_peer_id_t id = M->to_id;
   if (tgl_get_peer_type (id) == TGL_PEER_USER && tgl_get_peer_id (id) == TLS->our_id) {
     id = M->from_id;
   }
-  
+
   tgl_do_send_location (TLS, id, latitude, longitude, flags | TGL_SEND_MSG_FLAG_REPLY (reply_id), callback, callback_extra);
 }
 /* }}} */
@@ -2206,11 +2206,11 @@ void tgl_do_get_user_info (struct tgl_state *TLS, tgl_peer_id_t id, int offline_
 
 static void resend_query_cb (struct tgl_state *TLS, void *_q, int success) {
   assert (success);
-  
+
   bl_do_dc_signed (TLS, TLS->DC_working->id);
 
   struct query *q = _q;
-  
+
   clear_packet ();
   out_int (CODE_users_get_full_user);
   out_int (CODE_input_user_self);
@@ -2246,7 +2246,7 @@ struct download {
 static void end_load (struct tgl_state *TLS, struct download *D, void *callback, void *callback_extra) {
   TLS->cur_downloading_bytes -= D->size;
   TLS->cur_downloaded_bytes -= D->size;
-  
+
   if (D->fd >= 0) {
     close (D->fd);
   }
@@ -2290,7 +2290,7 @@ static int download_on_answer (struct tgl_state *TLS, struct query *q, void *DD)
   int len = DS_UF->bytes->len;
   TLS->cur_downloaded_bytes += len;
   //update_prompt ();
-  
+
   if (D->iv) {
     assert (!(len & 15));
     void *ptr = DS_UF->bytes->data;
@@ -2306,7 +2306,7 @@ static int download_on_answer (struct tgl_state *TLS, struct query *q, void *DD)
   } else {
     assert (write (D->fd, DS_UF->bytes->data, len) == len);
   }
-  
+
   D->offset += len;
   D->refcnt --;
   if (D->offset < D->size) {
@@ -2321,13 +2321,13 @@ static int download_on_answer (struct tgl_state *TLS, struct query *q, void *DD)
 }
 
 static int download_on_error (struct tgl_state *TLS, struct query *q, int error_code, int error_len, const char *error) {
-  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error); 
+  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error);
 
   struct download *D = q->extra;
   if (D->fd >= 0) {
     close (D->fd);
   }
-  
+
   if (q->callback) {
     ((void (*)(struct tgl_state *, void *, int, char *))q->callback) (TLS, q->callback_extra, 0, NULL);
   }
@@ -2369,16 +2369,16 @@ static void load_next_part (struct tgl_state *TLS, struct download *D, void *cal
     D->name = tstrdup (buf);
     struct stat st;
     if (stat (buf, &st) >= 0) {
-      D->offset = st.st_size;      
+      D->offset = st.st_size;
       if (D->offset >= D->size) {
         TLS->cur_downloading_bytes += D->size;
         TLS->cur_downloaded_bytes += D->offset;
         vlogprintf (E_NOTICE, "Already downloaded\n");
-        end_load (TLS, D, callback, callback_extra);        
+        end_load (TLS, D, callback, callback_extra);
         return;
       }
     }
-    
+
     TLS->cur_downloading_bytes += D->size;
     TLS->cur_downloaded_bytes += D->offset;
     //update_prompt ();
@@ -2414,7 +2414,7 @@ void tgl_do_load_photo_size (struct tgl_state *TLS, struct tgl_photo_size *P, vo
     }
     return;
   }
-  
+
   assert (P);
   struct download *D = talloc0 (sizeof (*D));
   D->id = 0;
@@ -2437,7 +2437,7 @@ void tgl_do_load_file_location (struct tgl_state *TLS, struct tgl_file_location 
     }
     return;
   }
-  
+
   assert (P);
   struct download *D = talloc0 (sizeof (*D));
   D->id = 0;
@@ -2453,12 +2453,12 @@ void tgl_do_load_file_location (struct tgl_state *TLS, struct tgl_file_location 
 }
 
 void tgl_do_load_photo (struct tgl_state *TLS, struct tgl_photo *photo, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, const char *filename), void *callback_extra) {
-  if (!photo->sizes_num) { 
+  if (!photo->sizes_num) {
     tgl_set_query_error (TLS, EINVAL, "Bad photo (no photo sizes");
     if (callback) {
       callback (TLS, callback_extra, 0, 0);
     }
-    return; 
+    return;
   }
   int max = -1;
   int maxi = 0;
@@ -2516,7 +2516,7 @@ void tgl_do_load_encr_document (struct tgl_state *TLS, struct tgl_encr_document 
     }
   }
   load_next_part (TLS, D, callback, callback_extra);
-      
+
   unsigned char md5[16];
   unsigned char str[64];
   memcpy (str, V->key, 32);
@@ -2531,7 +2531,7 @@ void tgl_do_load_encr_document (struct tgl_state *TLS, struct tgl_encr_document 
 static int import_auth_on_answer (struct tgl_state *TLS, struct query *q, void *D) {
   struct tl_ds_auth_authorization *DS_U = D;
   tglf_fetch_alloc_user_new (TLS, DS_U->user);
-  
+
   bl_do_dc_signed (TLS, ((struct tgl_dc *)q->extra)->id);
 
   if (q->callback) {
@@ -2546,7 +2546,7 @@ static struct query_methods import_auth_methods = {
   .type = TYPE_TO_PARAM(auth_authorization)
 };
 
-static int export_auth_on_answer (struct tgl_state *TLS, struct query *q, void *D) { 
+static int export_auth_on_answer (struct tgl_state *TLS, struct query *q, void *D) {
   struct tl_ds_auth_exported_authorization *DS_EA = D;
 
   bl_do_set_our_id (TLS, DS_LVAL (DS_EA->id));
@@ -2578,13 +2578,13 @@ void tgl_do_export_auth (struct tgl_state *TLS, int num, void (*callback) (struc
 /* {{{ Add contact */
 static int add_contact_on_answer (struct tgl_state *TLS, struct query *q, void *D) {
   struct tl_ds_contacts_imported_contacts *DS_CIC = D;
-  
+
   if (DS_LVAL (DS_CIC->imported->cnt) > 0) {
     vlogprintf (E_DEBUG, "Added successfully");
   } else {
     vlogprintf (E_DEBUG, "Not added");
   }
-  
+
   int n = DS_LVAL (DS_CIC->users->cnt);
 
   struct tgl_user **UL = talloc (n * sizeof (void *));
@@ -2647,7 +2647,7 @@ void tgl_do_del_contact (struct tgl_state *TLS, tgl_peer_id_t id, void (*callbac
   }
   clear_packet ();
   out_int (CODE_contacts_delete_contact);
-  
+
   tgl_peer_t *U = tgl_peer_get (TLS, id);
   if (U && U->user.access_hash) {
     out_int (CODE_input_user_foreign);
@@ -2680,9 +2680,9 @@ static void _tgl_do_msg_search (struct tgl_state *TLS, struct msg_search_extra *
 
 static int msg_search_on_answer (struct tgl_state *TLS, struct query *q, void *D) {
   struct tl_ds_messages_messages *DS_MM = D;
-  
+
   struct msg_search_extra *E = q->extra;
-  
+
   int n = DS_LVAL (DS_MM->messages->cnt);
 
   if (E->list_size - E->list_offset < n) {
@@ -2694,7 +2694,7 @@ static int msg_search_on_answer (struct tgl_state *TLS, struct query *q, void *D
     assert (E->ML);
     E->list_size = new_list_size;
   }
-  
+
   int i;
   for (i = 0; i < n; i++) {
     E->ML[i + E->list_offset] = tglf_fetch_alloc_message_new (TLS, DS_MM->messages->data[i]);
@@ -2707,19 +2707,19 @@ static int msg_search_on_answer (struct tgl_state *TLS, struct query *q, void *D
     if (E->limit < 0) { E->limit = 0; }
   }
   assert (E->limit >= 0);
-  
+
   for (i = 0; i < DS_LVAL (DS_MM->chats->cnt); i++) {
     tglf_fetch_alloc_chat_new (TLS, DS_MM->chats->data[i]);
   }
   for (i = 0; i < DS_LVAL (DS_MM->users->cnt); i++) {
     tglf_fetch_alloc_user_new (TLS, DS_MM->users->data[i]);
   }
- 
+
   if (E->limit <= 0 || DS_MM->magic == CODE_messages_messages) {
     if (q->callback) {
-      ((void (*)(struct tgl_state *, void *, int, int, struct tgl_message **))q->callback) (TLS, q->callback_extra, 1, E->list_offset, E->ML);      
+      ((void (*)(struct tgl_state *, void *, int, int, struct tgl_message **))q->callback) (TLS, q->callback_extra, 1, E->list_offset, E->ML);
     }
-  
+
     tfree_str (E->query);
     tfree (E->ML, sizeof (void *) * E->list_size);
     tfree (E, sizeof (*E));
@@ -2732,7 +2732,7 @@ static int msg_search_on_answer (struct tgl_state *TLS, struct query *q, void *D
 }
 
 static int msg_search_on_error (struct tgl_state *TLS, struct query *q, int error_code, int error_len, const char *error) {
-  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error); 
+  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error);
 
   struct msg_search_extra *E = q->extra;
   tfree_str (E->query);
@@ -2796,7 +2796,7 @@ static int get_state_on_answer (struct tgl_state *TLS, struct query *q, void *D)
 
   assert (TLS->locks & TGL_LOCK_DIFF);
   TLS->locks ^= TGL_LOCK_DIFF;
-  
+
   bl_do_set_pts (TLS, DS_LVAL (DS_US->pts));
   bl_do_set_qts (TLS, DS_LVAL (DS_US->qts));
   bl_do_set_date (TLS, DS_LVAL (DS_US->date));
@@ -2824,14 +2824,14 @@ static int lookup_state_on_answer (struct tgl_state *TLS, struct query *q, void 
 //int get_difference_active;
 static int get_difference_on_answer (struct tgl_state *TLS, struct query *q, void *D) {
   struct tl_ds_updates_difference *DS_UD = D;
-  
+
   assert (TLS->locks & TGL_LOCK_DIFF);
   TLS->locks ^= TGL_LOCK_DIFF;
 
   if (DS_UD->magic == CODE_updates_difference_empty) {
     bl_do_set_date (TLS, DS_LVAL (DS_UD->date));
     bl_do_set_seq (TLS, DS_LVAL (DS_UD->seq));
-    
+
     vlogprintf (E_DEBUG, "Empty difference. Seq = %d\n", TLS->seq);
     if (q->callback) {
       ((void (*)(struct tgl_state *, void *, int))q->callback) (TLS, q->callback_extra, 1);
@@ -2851,28 +2851,28 @@ static int get_difference_on_answer (struct tgl_state *TLS, struct query *q, voi
     for (i = 0; i < ml_pos; i++) {
       ML[i] = tglf_fetch_alloc_message_new (TLS, DS_UD->new_messages->data[i]);
     }
-    
+
     int el_pos = DS_LVAL (DS_UD->new_encrypted_messages->cnt);
     struct tgl_message **EL = talloc (el_pos * sizeof (void *));
     for (i = 0; i < el_pos; i++) {
       EL[i] = tglf_fetch_alloc_encrypted_message_new (TLS, DS_UD->new_encrypted_messages->data[i]);
     }
-    
+
     for (i = 0; i < DS_LVAL (DS_UD->other_updates->cnt); i++) {
       tglu_work_update_new (TLS, 1, DS_UD->other_updates->data[i]);
     }
-    
+
     for (i = 0; i < DS_LVAL (DS_UD->other_updates->cnt); i++) {
       tglu_work_update_new (TLS, -1, DS_UD->other_updates->data[i]);
     }
-    
+
     for (i = 0; i < ml_pos; i++) {
       bl_do_msg_update (TLS, ML[i]->id);
     }
     for (i = 0; i < el_pos; i++) {
       bl_do_msg_update (TLS, EL[i]->id);
     }
-    
+
     tfree (ML, ml_pos * sizeof (void *));
     tfree (EL, el_pos * sizeof (void *));
 
@@ -2881,7 +2881,7 @@ static int get_difference_on_answer (struct tgl_state *TLS, struct query *q, voi
       bl_do_set_qts (TLS, DS_LVAL (DS_UD->state->qts));
       bl_do_set_date (TLS, DS_LVAL (DS_UD->state->date));
       bl_do_set_seq (TLS, DS_LVAL (DS_UD->state->seq));
-      
+
       if (q->callback) {
         ((void (*)(struct tgl_state *, void *, int))q->callback) (TLS, q->callback_extra, 1);
       }
@@ -2889,11 +2889,11 @@ static int get_difference_on_answer (struct tgl_state *TLS, struct query *q, voi
       bl_do_set_pts (TLS, DS_LVAL (DS_UD->intermediate_state->pts));
       bl_do_set_qts (TLS, DS_LVAL (DS_UD->intermediate_state->qts));
       bl_do_set_date (TLS, DS_LVAL (DS_UD->intermediate_state->date));
-      
+
       tgl_do_get_difference (TLS, 0, q->callback, q->callback_extra);
     }
   }
-  return 0;   
+  return 0;
 }
 
 static struct query_methods lookup_state_methods = {
@@ -2973,7 +2973,7 @@ void tgl_do_add_user_to_chat (struct tgl_state *TLS, tgl_peer_id_t chat_id, tgl_
   clear_packet ();
   out_int (CODE_messages_add_chat_user);
   out_int (tgl_get_peer_id (chat_id));
-  
+
   assert (tgl_get_peer_type (id) == TGL_PEER_USER);
   tgl_peer_t *U = tgl_peer_get (TLS, id);
   if (U && U->user.access_hash) {
@@ -2985,7 +2985,7 @@ void tgl_do_add_user_to_chat (struct tgl_state *TLS, tgl_peer_id_t chat_id, tgl_
     out_int (tgl_get_peer_id (id));
   }
   out_int (limit);
-    
+
   tglq_send_query (TLS, TLS->DC_working, packet_ptr - packet_buffer, packet_buffer, &send_msgs_methods, 0, callback, callback_extra);
 }
 
@@ -2993,7 +2993,7 @@ void tgl_do_del_user_from_chat (struct tgl_state *TLS, tgl_peer_id_t chat_id, tg
   clear_packet ();
   out_int (CODE_messages_delete_chat_user);
   out_int (tgl_get_peer_id (chat_id));
-  
+
   assert (tgl_get_peer_type (id) == TGL_PEER_USER);
   tgl_peer_t *U = tgl_peer_get (TLS, id);
   if (U && U->user.access_hash) {
@@ -3014,7 +3014,7 @@ void tgl_do_del_user_from_chat (struct tgl_state *TLS, tgl_peer_id_t chat_id, tg
 void tgl_do_create_secret_chat (struct tgl_state *TLS, tgl_peer_id_t id, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, struct tgl_secret_chat *E), void *callback_extra) {
   assert (tgl_get_peer_type (id) == TGL_PEER_USER);
   tgl_peer_t *U = tgl_peer_get (TLS, id);
-  if (!U) { 
+  if (!U) {
     tgl_set_query_error (TLS, EINVAL, "Can not create secret chat with unknown user");
     if (callback) {
       callback (TLS, callback_extra, 0, NULL);
@@ -3022,7 +3022,7 @@ void tgl_do_create_secret_chat (struct tgl_state *TLS, tgl_peer_id_t id, void (*
     return;
   }
 
-  tgl_do_create_encr_chat_request (TLS, tgl_get_peer_id (id), callback, callback_extra); 
+  tgl_do_create_encr_chat_request (TLS, tgl_get_peer_id (id), callback, callback_extra);
 }
 /* }}} */
 
@@ -3037,7 +3037,7 @@ void tgl_do_create_group_chat (struct tgl_state *TLS, int users_num, tgl_peer_id
   for (i = 0; i < users_num; i++) {
     tgl_peer_id_t id = ids[i];
     tgl_peer_t *U = tgl_peer_get (TLS, id);
-    if (!U || tgl_get_peer_type (id) != TGL_PEER_USER) { 
+    if (!U || tgl_get_peer_type (id) != TGL_PEER_USER) {
       tgl_set_query_error (TLS, EINVAL, "Can not create chat with unknown user");
       if (callback) {
         callback (TLS, callback_extra, 0);
@@ -3062,12 +3062,12 @@ void tgl_do_create_group_chat (struct tgl_state *TLS, int users_num, tgl_peer_id
 
 static int delete_msg_on_answer (struct tgl_state *TLS, struct query *q, void *D) {
   struct tl_ds_messages_affected_messages *DS_MAM = D;
-  
+
   struct tgl_message *M = tgl_message_get (TLS, (long)q->extra);
   if (M) {
     bl_do_message_delete (TLS, M);
   }
-  
+
   int r = tgl_check_pts_diff (TLS, DS_LVAL (DS_MAM->pts), DS_LVAL (DS_MAM->pts_count));
 
   if (r > 0) {
@@ -3102,13 +3102,13 @@ static int export_card_on_answer (struct tgl_state *TLS, struct query *q, void *
   struct tl_ds_vector *DS_V = D;
 
   int n = DS_LVAL (DS_V->f1);
-  
+
   int *r = talloc (4 * n);
   int i;
   for (i = 0; i < n; i++) {
     r[i] = *(int *)DS_V->f2[i];
   }
-  
+
   if (q->callback) {
     ((void (*)(struct tgl_state *, void *, int, int, int *))q->callback) (TLS, q->callback_extra, 1, n, r);
   }
@@ -3133,7 +3133,7 @@ void tgl_do_export_card (struct tgl_state *TLS, void (*callback)(struct tgl_stat
 
 static int import_card_on_answer (struct tgl_state *TLS, struct query *q, void *D) {
   struct tgl_user *U = tglf_fetch_alloc_user_new (TLS, D);
-  
+
   if (q->callback) {
     ((void (*)(struct tgl_state *, void *, int, struct tgl_user *))q->callback) (TLS, q->callback_extra, 1, U);
   }
@@ -3142,7 +3142,7 @@ static int import_card_on_answer (struct tgl_state *TLS, struct query *q, void *
 
 static struct query_methods import_card_methods = {
   .on_answer = import_card_on_answer,
-  .on_error = q_ptr_on_error, 
+  .on_error = q_ptr_on_error,
   .type = TYPE_TO_PARAM (user)
 };
 
@@ -3191,7 +3191,7 @@ static struct query_methods send_typing_methods = {
 };
 
 void tgl_do_send_typing (struct tgl_state *TLS, tgl_peer_id_t id, enum tgl_typing_status status, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success), void *callback_extra) {
-  if (tgl_get_peer_type (id) != TGL_PEER_ENCR_CHAT) {  
+  if (tgl_get_peer_type (id) != TGL_PEER_ENCR_CHAT) {
     clear_packet ();
     out_int (CODE_messages_set_typing);
     out_peer_id (TLS, id);
@@ -3262,7 +3262,7 @@ void tgl_do_send_extf (struct tgl_state *TLS, const char *data, int data_len, vo
 
   ext_query_methods.type = tglf_extf_store (TLS, data, data_len);
 
-  if (ext_query_methods.type) { 
+  if (ext_query_methods.type) {
     tglq_send_query (TLS, TLS->DC_working, packet_ptr - packet_buffer, packet_buffer, &ext_query_methods, 0, callback, callback_extra);
   }
 }
@@ -3307,7 +3307,7 @@ static int get_messages_on_answer (struct tgl_state *TLS, struct query *q, void 
       if (DS_LVAL (DS_MM->messages->cnt) > 0) {
         ((void (*)(struct tgl_state *, void *, int, struct tgl_message *))q->callback)(TLS, q->callback_extra, 1, *ML);
       } else {
-        tgl_set_query_error (TLS, ENOENT, "no such message");        
+        tgl_set_query_error (TLS, ENOENT, "no such message");
         ((void (*)(struct tgl_state *, void *, int, struct tgl_message *))q->callback)(TLS, q->callback_extra, 0, NULL);
       }
     }
@@ -3369,7 +3369,7 @@ void tgl_do_export_chat_link (struct tgl_state *TLS, tgl_peer_id_t id, void (*ca
   if (tgl_get_peer_type (id) != TGL_PEER_CHAT) {
     tgl_set_query_error (TLS, EINVAL, "Can only export chat link for chat");
     if (callback) {
-      callback (TLS, callback_extra, 0, NULL);      
+      callback (TLS, callback_extra, 0, NULL);
     }
     return;
   }
@@ -3429,7 +3429,7 @@ static int set_password_on_error (struct tgl_state *TLS, struct query *q, int er
       return 0;
     }
   }
-  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error); 
+  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error);
   if (q->callback) {
     ((void (*)(struct tgl_state *, void *, int))q->callback)(TLS, q->callback_extra, 0);
   }
@@ -3476,12 +3476,12 @@ static void tgl_do_act_set_password (struct tgl_state *TLS, const char *current_
     tglt_secure_random (d + l, 16);
     l += 16;
     memcpy (s, d, l);
-    
+
     memcpy (s + l, new_password, new_password_len);
     memcpy (s + l + new_password_len, d, l);
 
     SHA256 ((void *)s, 2 * l + new_password_len, shab);
-    
+
     out_cstring (d, l);
     out_cstring ((void *)shab, 32);
     out_cstring (hint, hint_len);
@@ -3489,7 +3489,7 @@ static void tgl_do_act_set_password (struct tgl_state *TLS, const char *current_
     out_int (0);
   }
 
-    
+
   tglq_send_query (TLS, TLS->DC_working, packet_ptr - packet_buffer, packet_buffer, &set_password_methods, 0, callback, callback_extra);
 }
 
@@ -3508,7 +3508,7 @@ struct change_password_extra {
   void *callback_extra;
 };
 
-void tgl_on_new_pwd (struct tgl_state *TLS, const char *pwd, void *_T);
+void tgl_on_new_pwd (struct tgl_state *TLS, const char *pwd[], void *_T);
 void tgl_on_new2_pwd (struct tgl_state *TLS, const char *pwd, void *_T) {
   struct change_password_extra *E = _T;
   if (strlen (pwd) != (size_t)E->new_password_len || memcmp (E->new_password, pwd, E->new_password_len)) {
@@ -3516,7 +3516,7 @@ void tgl_on_new2_pwd (struct tgl_state *TLS, const char *pwd, void *_T) {
     E->new_password = NULL;
     E->new_password_len = 0;
     vlogprintf (E_ERROR, "passwords do not match\n");
-    TLS->callback.get_string (TLS, "new password: ", 1, tgl_on_new_pwd, E);
+    TLS->callback.get_values (TLS, tgl_new_password, "new password: ", 2, tgl_on_new_pwd, E);
     return;
   }
   tgl_do_act_set_password (TLS, E->current_password, E->current_password_len,
@@ -3525,7 +3525,7 @@ void tgl_on_new2_pwd (struct tgl_state *TLS, const char *pwd, void *_T) {
                                 E->new_salt, E->new_salt_len,
                                 E->hint, E->hint_len,
                                 E->callback, E->callback_extra);
- 
+
   tfree (E->current_password, E->current_password_len);
   tfree (E->new_password, E->new_password_len);
   tfree (E->current_salt, E->current_salt_len);
@@ -3534,18 +3534,18 @@ void tgl_on_new2_pwd (struct tgl_state *TLS, const char *pwd, void *_T) {
   tfree (E, sizeof (*E));
 }
 
-void tgl_on_new_pwd (struct tgl_state *TLS, const char *pwd, void *_T) {
+void tgl_on_new_pwd (struct tgl_state *TLS, const char *pwd[], void *_T) {
   struct change_password_extra *E = _T;
-  E->new_password_len = strlen (pwd);
-  E->new_password = tmemdup (pwd, E->new_password_len);
-  TLS->callback.get_string (TLS, "retype new password: ", 1, tgl_on_new2_pwd, E);
+  E->new_password_len = strlen (pwd[0]);
+  E->new_password = tmemdup (pwd[0], E->new_password_len);
+  tgl_on_new2_pwd(TLS, pwd[1], E);
 }
 
-void tgl_on_old_pwd (struct tgl_state *TLS, const char *pwd, void *_T) {
+void tgl_on_old_pwd (struct tgl_state *TLS, const char *pwd[], void *_T) {
   struct change_password_extra *E = _T;
-  E->current_password_len = strlen (pwd);
-  E->current_password = tmemdup (pwd, E->current_password_len);
-  TLS->callback.get_string (TLS, "new password: ", 1, tgl_on_new_pwd, E);
+  E->current_password_len = strlen (pwd[0]);
+  E->current_password = tmemdup (pwd[0], E->current_password_len);
+  tgl_on_new_pwd(TLS, pwd + 1, E);
 }
 
 static int set_get_password_on_answer (struct tgl_state *TLS, struct query *q, void *D) {
@@ -3554,7 +3554,7 @@ static int set_get_password_on_answer (struct tgl_state *TLS, struct query *q, v
   char *new_hint = q->extra;
 
   struct change_password_extra *E = talloc0 (sizeof (*E));
-  
+
   if (DS_AP->current_salt) {
     E->current_salt_len = DS_AP->current_salt->len;
     E->current_salt = tmemdup (DS_AP->current_salt->data, E->current_salt_len);
@@ -3573,11 +3573,11 @@ static int set_get_password_on_answer (struct tgl_state *TLS, struct query *q, v
   E->callback_extra = q->callback_extra;
 
   if (DS_AP->magic == CODE_account_no_password) {
-    TLS->callback.get_string (TLS, "new password: ", 1, tgl_on_new_pwd, E);
+    TLS->callback.get_values (TLS, tgl_new_password, "new password: ", 2, tgl_on_new_pwd, E);
   } else {
     static char s[512];
     snprintf (s, 511, "old password (hint %.*s): ", DS_RSTR (DS_AP->hint));
-    TLS->callback.get_string (TLS, s, 1, tgl_on_old_pwd, E);
+    TLS->callback.get_values (TLS, tgl_cur_and_new_password, s, 3, tgl_on_old_pwd, E);
   }
   return 0;
 }
@@ -3604,7 +3604,7 @@ static int check_password_on_error (struct tgl_state *TLS, struct query *q, int 
     return 0;
   }
   TLS->locks ^= TGL_LOCK_PASSWORD;
-  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error); 
+  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error);
   if (q->callback) {
     ((void (*)(struct tgl_state *, void *, int))q->callback)(TLS, q->callback_extra, 0);
   }
@@ -3633,25 +3633,25 @@ struct check_password_extra {
   void *callback_extra;
 };
 
-static void tgl_pwd_got (struct tgl_state *TLS, const char *pwd, void *_T) {
+static void tgl_pwd_got (struct tgl_state *TLS, const char *pwd[], void *_T) {
   struct check_password_extra *E = _T;
-  
+
   clear_packet ();
   static char s[512];
   static unsigned char shab[32];
 
   assert (E->current_salt_len <= 128);
-  assert (strlen (pwd) <= 128);
+  assert (strlen (pwd[0]) <= 128);
 
   out_int (CODE_auth_check_password);
 
-  if (pwd && E->current_salt_len) {
+  if (pwd[0] && E->current_salt_len) {
     int l = E->current_salt_len;
     memcpy (s, E->current_salt, l);
-    
-    int r = strlen (pwd);
-    strcpy (s + l, pwd);
-  
+
+    int r = strlen (pwd[0]);
+    strcpy (s + l, pwd[0]);
+
     memcpy (s + l + r, E->current_salt, l);
 
     SHA256 ((void *)s, 2 * l + r, shab);
@@ -3668,7 +3668,7 @@ static void tgl_pwd_got (struct tgl_state *TLS, const char *pwd, void *_T) {
 
 static int check_get_password_on_error (struct tgl_state *TLS, struct query *q, int error_code, int error_len, const char *error) {
   TLS->locks ^= TGL_LOCK_PASSWORD;
-  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error); 
+  tgl_set_query_error (TLS, EPROTO, "RPC_CALL_FAIL %d: %.*s", error_code, error_len, error);
   if (q->callback) {
     ((void (*)(struct tgl_state *, void *, int))q->callback) (TLS, q->callback_extra, 0);
   }
@@ -3695,7 +3695,7 @@ static int check_get_password_on_answer (struct tgl_state *TLS, struct query *q,
   E->callback = q->callback;
   E->callback_extra = q->callback_extra;
 
-  TLS->callback.get_string (TLS, s, 1, tgl_pwd_got, E);
+  TLS->callback.get_values (TLS, tgl_cur_password, s, 1, tgl_pwd_got, E);
   return 0;
 }
 
@@ -3715,7 +3715,7 @@ void tgl_do_check_password (struct tgl_state *TLS, void (*callback)(struct tgl_s
 
 /* {{{ send broadcast */
 void tgl_do_send_broadcast (struct tgl_state *TLS, int num, tgl_peer_id_t id[], const char *text, int text_len, unsigned long long flags, void (*callback)(struct tgl_state *TLS, void *extra, int success, int num, struct tgl_message *ML[]), void *callback_extra) {
-  
+
   assert (num <= 1000);
 
   struct messages_send_extra *E = talloc0 (sizeof (*E));
@@ -3752,7 +3752,7 @@ void tgl_do_send_broadcast (struct tgl_state *TLS, int num, tgl_peer_id_t id[], 
   out_int (num);
   for (i = 0; i < num; i++) {
     assert (tgl_get_peer_type (id[i]) == TGL_PEER_USER);
-   
+
     struct tgl_user *U = (void *)tgl_peer_get (TLS, id[i]);
     if (U && U->access_hash) {
       out_int (CODE_input_user_foreign);
@@ -3763,7 +3763,7 @@ void tgl_do_send_broadcast (struct tgl_state *TLS, int num, tgl_peer_id_t id[], 
       out_int (tgl_get_peer_id (id[i]));
     }
   }
-  
+
   out_int (CODE_vector);
   out_int (num);
   for (i = 0; i < num; i++) {
@@ -3772,7 +3772,7 @@ void tgl_do_send_broadcast (struct tgl_state *TLS, int num, tgl_peer_id_t id[], 
   out_cstring (text, text_len);
 
   out_int (CODE_message_media_empty);
-  
+
   tglq_send_query (TLS, TLS->DC_working, packet_ptr - packet_buffer, packet_buffer, &send_msgs_methods, E, callback, callback_extra);
 }
 /* }}} */
@@ -3799,9 +3799,9 @@ void tgl_do_block_user (struct tgl_state *TLS, tgl_peer_id_t id, void (*callback
     }
     return;
   }
-  
+
   clear_packet ();
-  
+
   out_int (CODE_contacts_block);
   tgl_peer_t *U = tgl_peer_get (TLS, id);
   if (U && U->user.access_hash) {
@@ -3823,9 +3823,9 @@ void tgl_do_unblock_user (struct tgl_state *TLS, tgl_peer_id_t id, void (*callba
     }
     return;
   }
-  
+
   clear_packet ();
-  
+
   out_int (CODE_contacts_unblock);
   tgl_peer_t *U = tgl_peer_get (TLS, id);
   if (U && U->user.access_hash) {
@@ -3914,12 +3914,12 @@ void tgl_do_request_exchange (struct tgl_state *TLS, struct tgl_secret_chat *E) 
   //bl_do_encr_chat_exchange_request (TLS, E, id, s);
   int rst =  tgl_sce_requested;
   bl_do_encr_chat_exchange_new (TLS, E, &id, NULL, &rst);
-  
+
   BIGNUM *a = BN_bin2bn (s, 256, 0);
   ensure_ptr (a);
-  BIGNUM *p = BN_bin2bn (TLS->encr_prime, 256, 0); 
+  BIGNUM *p = BN_bin2bn (TLS->encr_prime, 256, 0);
   ensure_ptr (p);
- 
+
   BIGNUM *g = BN_new ();
   ensure_ptr (g);
 
@@ -3929,7 +3929,7 @@ void tgl_do_request_exchange (struct tgl_state *TLS, struct tgl_secret_chat *E) 
   ensure_ptr (r);
 
   ensure (BN_mod_exp (r, g, a, p, TLS->BN_ctx));
-  
+
   static unsigned char kk[256];
   memset (kk, 0, sizeof (kk));
   BN_bn2bin (r, kk + (256 - BN_num_bytes (r)));
@@ -3938,8 +3938,8 @@ void tgl_do_request_exchange (struct tgl_state *TLS, struct tgl_secret_chat *E) 
   BN_clear_free (g);
   BN_clear_free (p);
   BN_clear_free (r);
-  
-  static int action[70];  
+
+  static int action[70];
   action[0] = CODE_decrypted_message_action_request_key;
   *(long long *)(action + 1) = E->exchange_id;
   action[3] = 0x100fe;
@@ -3949,7 +3949,7 @@ void tgl_do_request_exchange (struct tgl_state *TLS, struct tgl_secret_chat *E) 
   tglt_secure_random (&t, 8);
 
   bl_do_send_message_action_encr (TLS, t, TLS->our_id, tgl_get_peer_type (E->id), tgl_get_peer_id (E->id), time (0), 68, action);
-  
+
   struct tgl_message *M = tgl_message_get (TLS, t);
   assert (M);
   assert (M->action.type == tgl_message_action_request_key);
@@ -3970,7 +3970,7 @@ void tgl_do_accept_exchange (struct tgl_state *TLS, struct tgl_secret_chat *E, l
   //  ctx = BN_CTX_new ();
   //  ensure_ptr (ctx);
   //}
-  BIGNUM *p = TLS->encr_prime_bn; 
+  BIGNUM *p = TLS->encr_prime_bn;
   ensure_ptr (p);
   BIGNUM *r = BN_new ();
   ensure_ptr (r);
@@ -3981,15 +3981,15 @@ void tgl_do_accept_exchange (struct tgl_state *TLS, struct tgl_secret_chat *E, l
   BN_bn2bin (r, kk + (256 - BN_num_bytes (r)));
 
   bl_do_encr_chat_exchange_accept (TLS, E, exchange_id, kk);
-  
+
   ensure (BN_set_word (g_a, TLS->encr_root));
   ensure (BN_mod_exp (r, g_a, b, p, TLS->BN_ctx));
-  
+
   static unsigned char buf[256];
   memset (buf, 0, sizeof (buf));
   BN_bn2bin (r, buf + (256 - BN_num_bytes (r)));
-  
-  static int action[70];  
+
+  static int action[70];
   action[0] = CODE_decrypted_message_action_accept_key;
   *(long long *)(action + 1) = E->exchange_id;
   action[3] = 0x100fe;
@@ -4004,18 +4004,18 @@ void tgl_do_accept_exchange (struct tgl_state *TLS, struct tgl_secret_chat *E, l
   BN_clear_free (b);
   BN_clear_free (g_a);
   BN_clear_free (r);
-  
+
   struct tgl_message *M = tgl_message_get (TLS, t);
   assert (M);
   assert (M->action.type == tgl_message_action_accept_key);
   tgl_do_send_msg (TLS, M, 0, 0);*/
 }
-  
+
 void tgl_do_confirm_exchange (struct tgl_state *TLS, struct tgl_secret_chat *E, int sen_nop) {
   /*bl_do_encr_chat_exchange_confirm (TLS, E);
   if (sen_nop) {
     int action = CODE_decrypted_message_action_noop;
-  
+
     long long t;
     tglt_secure_random (&t, 8);
 
@@ -4030,8 +4030,8 @@ void tgl_do_confirm_exchange (struct tgl_state *TLS, struct tgl_secret_chat *E, 
 
 void tgl_do_commit_exchange (struct tgl_state *TLS, struct tgl_secret_chat *E, unsigned char gb[]) {
   /*assert (TLS->encr_prime);
-  
-  BIGNUM *g_b = BN_bin2bn (gb, 256, 0);  
+
+  BIGNUM *g_b = BN_bin2bn (gb, 256, 0);
   ensure_ptr (g_b);
   assert (tglmp_check_g_a (TLS, TLS->encr_prime_bn, g_b) >= 0);
 
@@ -4045,31 +4045,31 @@ void tgl_do_commit_exchange (struct tgl_state *TLS, struct tgl_secret_chat *E, u
 
   static unsigned char s[256];
   memset (s, 0, 256);
-  
+
   BN_bn2bin (r, s + (256 - BN_num_bytes (r)));
-  
+
   BN_clear_free (g_b);
   BN_clear_free (r);
   BN_clear_free (a);
- 
+
   static unsigned char sh[20];
   SHA1 (s, 256, sh);
-  
+
   int action[4];
   action[0] = CODE_decrypted_message_action_commit_key;
   *(long long *)(action + 1) = E->exchange_id;
   *(long long *)(action + 3) = *(long long *)(sh + 12);
-  
+
   long long t;
   tglt_secure_random (&t, 8);
 
   bl_do_send_message_action_encr (TLS, t, TLS->our_id, tgl_get_peer_type (E->id), tgl_get_peer_id (E->id), time (0), 5, action);
-  
+
   struct tgl_message *M = tgl_message_get (TLS, t);
   assert (M);
   assert (M->action.type == tgl_message_action_commit_key);
   tgl_do_send_msg (TLS, M, 0, 0);
-  
+
   bl_do_encr_chat_exchange_commit (TLS, E, s);*/
 }
 
@@ -4089,12 +4089,12 @@ void tgl_export_auth_callback (struct tgl_state *TLS, void *arg, int success) {
   assert (success);
   int i;
   for (i = 0; i <= TLS->max_dc_num; i++) if (TLS->DC_list[i] && !tgl_signed_dc (TLS, TLS->DC_list[i])) {
-    return; 
+    return;
   }
   if (TLS->callback.logged_in) {
     TLS->callback.logged_in (TLS);
   }
-  
+
   tglm_send_all_unsent (TLS);
   tgl_do_get_difference (TLS, 0, tgl_started_cb, 0);
 }
@@ -4103,7 +4103,7 @@ void tgl_export_all_auth (struct tgl_state *TLS) {
   int i;
   int ok = 1;
   for (i = 0; i <= TLS->max_dc_num; i++) if (TLS->DC_list[i] && !tgl_signed_dc (TLS, TLS->DC_list[i])) {
-    tgl_do_export_auth (TLS, i, tgl_export_auth_callback, TLS->DC_list[i]);   
+    tgl_do_export_auth (TLS, i, tgl_export_auth_callback, TLS->DC_list[i]);
     ok = 0;
   }
   if (ok) {
@@ -4127,7 +4127,7 @@ struct sign_up_extra {
   int last_name_len;
 };
 
-void tgl_sign_in_code (struct tgl_state *TLS, const char *code, void *_T);
+void tgl_sign_in_code (struct tgl_state *TLS, const char *code[], void *_T);
 void tgl_sign_in_result (struct tgl_state *TLS, void *_T, int success, struct tgl_user *U) {
   struct sign_up_extra *E = _T;
   if (success) {
@@ -4136,24 +4136,24 @@ void tgl_sign_in_result (struct tgl_state *TLS, void *_T, int success, struct tg
     tfree (E, sizeof (*E));
   } else {
     vlogprintf (E_ERROR, "incorrect code\n");
-    TLS->callback.get_string (TLS, "code ('call' for phone call):", 0, tgl_sign_in_code, E);
+    TLS->callback.get_values (TLS, tgl_code, "code ('call' for phone call):", 1, tgl_sign_in_code, E);
     return;
   }
   tgl_export_all_auth (TLS);
 }
 
-void tgl_sign_in_code (struct tgl_state *TLS, const char *code, void *_T) {
+void tgl_sign_in_code (struct tgl_state *TLS, const char *code[], void *_T) {
   struct sign_up_extra *E = _T;
-  if (!strcmp (code, "call")) {
+  if (!strcmp (code[0], "call")) {
     tgl_do_phone_call (TLS, E->phone, E->phone_len, E->hash, E->hash_len, 0, 0);
-    TLS->callback.get_string (TLS, "code ('call' for phone call):", 0, tgl_sign_in_code, E);
+    TLS->callback.get_values (TLS, tgl_code, "code ('call' for phone call):", 1, tgl_sign_in_code, E);
     return;
   }
-  
-  tgl_do_send_code_result (TLS, E->phone, E->phone_len, E->hash, E->hash_len, code, strlen (code), tgl_sign_in_result, E);
+
+  tgl_do_send_code_result (TLS, E->phone, E->phone_len, E->hash, E->hash_len, code[0], strlen (code[0]), tgl_sign_in_result, E);
 }
 
-void tgl_sign_up_code (struct tgl_state *TLS, const char *code, void *_T);
+void tgl_sign_up_code (struct tgl_state *TLS, const char *code[], void *_T);
 void tgl_sign_up_result (struct tgl_state *TLS, void *_T, int success, struct tgl_user *U) {
   struct sign_up_extra *E = _T;
   if (success) {
@@ -4164,49 +4164,52 @@ void tgl_sign_up_result (struct tgl_state *TLS, void *_T, int success, struct tg
     tfree (E, sizeof (*E));
   } else {
     vlogprintf (E_ERROR, "incorrect code\n");
-    TLS->callback.get_string (TLS, "code ('call' for phone call):", 0, tgl_sign_up_code, E);
+    TLS->callback.get_values (TLS, tgl_code, "code ('call' for phone call):", 1, tgl_sign_up_code, E);
     return;
   }
   tgl_export_all_auth (TLS);
 }
 
-void tgl_sign_up_code (struct tgl_state *TLS, const char *code, void *_T) {
+void tgl_sign_up_code (struct tgl_state *TLS, const char *code[], void *_T) {
   struct sign_up_extra *E = _T;
-  if (!strcmp (code, "call")) {
+  if (!strcmp (code[0], "call")) {
     tgl_do_phone_call (TLS, E->phone, E->phone_len, E->hash, E->hash_len, 0, 0);
-    TLS->callback.get_string (TLS, "code ('call' for phone call):", 0, tgl_sign_up_code, E);
+    TLS->callback.get_values (TLS, tgl_code, "code ('call' for phone call):", 1, tgl_sign_up_code, E);
     return;
   }
-  
-  tgl_do_send_code_result_auth (TLS, E->phone, E->phone_len, E->hash, E->hash_len, code, strlen (code), E->first_name, E->first_name_len, E->last_name, E->last_name_len, tgl_sign_up_result, E);
+
+  tgl_do_send_code_result_auth (TLS, E->phone, E->phone_len, E->hash, E->hash_len, code[0], strlen (code[0]), E->first_name, E->first_name_len, E->last_name, E->last_name_len, tgl_sign_up_result, E);
 }
 
 
-void tgl_last_name_cb (struct tgl_state *TLS, const char *last_name, void *_T) {
-  struct sign_up_extra *E = _T;
+void tgl_set_last_name (struct tgl_state *TLS, const char *last_name, struct sign_up_extra *E) {
   E->last_name_len = strlen (last_name);
   E->last_name = tmemdup (last_name, E->last_name_len);
-  TLS->callback.get_string (TLS, "code ('call' for phone call):", 0, tgl_sign_up_code, E);
 }
 
-void tgl_first_name_cb (struct tgl_state *TLS, const char *first_name, void *_T) {
-  struct sign_up_extra *E = _T;
+int tgl_set_first_name (struct tgl_state *TLS, const char *first_name, struct sign_up_extra *E) {
   if (strlen (first_name) < 1) {
-    TLS->callback.get_string (TLS, "First name:", 0, tgl_first_name_cb, E);
-    return;
+    return -1;
   }
 
   E->first_name_len = strlen (first_name);
   E->first_name = tmemdup (first_name, E->first_name_len);
-  TLS->callback.get_string (TLS, "Last name:", 0, tgl_last_name_cb, E);
+  return 0;
 }
 
-void tgl_register_cb (struct tgl_state *TLS, const char *yn, void *_T) {
+void tgl_register_cb (struct tgl_state *TLS, const char *rinfo[], void *_T) {
   struct sign_up_extra *E = _T;
+  const char *yn = rinfo[0];
   if (strlen (yn) > 1) {
-    TLS->callback.get_string (TLS, "register [Y/n]:", 0, tgl_register_cb, E);
+    TLS->callback.get_values (TLS, tgl_register_info, "registration info:", 3, tgl_register_cb, E);
   } else if (strlen (yn) == 0 || *yn == 'y' || *yn == 'Y') {
-    TLS->callback.get_string (TLS, "First name:", 0, tgl_first_name_cb, E);
+    if (!tgl_set_first_name(TLS, rinfo[1], E)) {
+      tgl_set_last_name(TLS, rinfo[2], E);
+      TLS->callback.get_values (TLS, tgl_code, "code ('call' for phone call):", 1, tgl_sign_up_code, E);
+    }
+    else {
+      TLS->callback.get_values (TLS, tgl_register_info, "registration info:", 3, tgl_register_cb, E);
+    }
   } else if (*yn == 'n' || *yn == 'N') {
     vlogprintf (E_ERROR, "stopping registration");
     tfree (E->phone, E->phone_len);
@@ -4214,11 +4217,11 @@ void tgl_register_cb (struct tgl_state *TLS, const char *yn, void *_T) {
     tfree (E, sizeof (*E));
     tgl_login (TLS);
   } else {
-    TLS->callback.get_string (TLS, "register [Y/n]:", 0, tgl_register_cb, E);
+    TLS->callback.get_values (TLS, tgl_register_info, "registration info:", 3, tgl_register_cb, E);
   }
 }
 
-void tgl_sign_in_phone (struct tgl_state *TLS, const char *phone, void *arg);
+void tgl_sign_in_phone (struct tgl_state *TLS, const char *phone[], void *arg);
 void tgl_sign_in_phone_cb (struct tgl_state *TLS, void *extra, int success, int registered, const char *mhash) {
   struct sign_up_extra *E = extra;
   if (!success) {
@@ -4226,7 +4229,7 @@ void tgl_sign_in_phone_cb (struct tgl_state *TLS, void *extra, int success, int 
 
     tfree (E->phone, E->phone_len);
     tfree (E, sizeof (*E));
-    TLS->callback.get_string (TLS, "phone number:", 0, tgl_sign_in_phone, NULL);
+    TLS->callback.get_values (TLS, tgl_phone_number, "phone number:", 1, tgl_sign_in_phone, NULL);
     return;
   }
 
@@ -4234,41 +4237,41 @@ void tgl_sign_in_phone_cb (struct tgl_state *TLS, void *extra, int success, int 
   E->hash = tmemdup (mhash, E->hash_len);
 
   if (registered) {
-    TLS->callback.get_string (TLS, "code ('call' for phone call):", 0, tgl_sign_in_code, E);
+    TLS->callback.get_values (TLS, tgl_code, "code ('call' for phone call):", 1, tgl_sign_in_code, E);
   } else {
-    TLS->callback.get_string (TLS, "register [Y/n]:", 0, tgl_register_cb, E);
+    TLS->callback.get_values (TLS, tgl_register_info, "registration info:", 3, tgl_register_cb, E);
   }
 }
 
-void tgl_sign_in_phone (struct tgl_state *TLS, const char *phone, void *arg) {
+void tgl_sign_in_phone (struct tgl_state *TLS, const char *phone[], void *arg) {
   struct sign_up_extra *E = talloc0 (sizeof (*E));
-  E->phone_len = strlen (phone);
-  E->phone = tmemdup (phone, E->phone_len);
-  
+  E->phone_len = strlen (phone[0]);
+  E->phone = tmemdup (phone[0], E->phone_len);
+
   tgl_do_send_code (TLS, E->phone, E->phone_len, tgl_sign_in_phone_cb, E);
 }
 
-void tgl_bot_hash (struct tgl_state *TLS, const char *code, void *arg);
+void tgl_bot_hash_cb (struct tgl_state *TLS, const char *code[], void *arg);
 
 void tgl_sign_in_bot_cb (struct tgl_state *TLS, void *_T, int success, struct tgl_user *U) {
   if (!success) {
     vlogprintf (E_ERROR, "incorrect bot hash\n");
-    TLS->callback.get_string (TLS, "bot hash:", 0, tgl_bot_hash, NULL);
+    TLS->callback.get_values (TLS, tgl_bot_hash, "bot hash:", 1, tgl_bot_hash_cb, NULL);
     return;
   }
   tgl_export_all_auth (TLS);
 }
 
-void tgl_bot_hash (struct tgl_state *TLS, const char *code, void *arg) {
-  tgl_do_send_bot_auth (TLS, code, strlen (code), tgl_sign_in_bot_cb, NULL);
+void tgl_bot_hash_cb (struct tgl_state *TLS, const char *code[], void *arg) {
+  tgl_do_send_bot_auth (TLS, code[0], strlen (code[0]), tgl_sign_in_bot_cb, NULL);
 }
 
 void tgl_sign_in (struct tgl_state *TLS) {
   if (!tgl_signed_dc (TLS, TLS->DC_working)) {
     if (TLS->is_bot) {
-      TLS->callback.get_string (TLS, "bot hash:", 0, tgl_bot_hash, NULL);
+      TLS->callback.get_values (TLS, tgl_bot_hash, "bot hash:", 0, tgl_bot_hash_cb, NULL);
     } else {
-      TLS->callback.get_string (TLS, "phone number:", 0, tgl_sign_in_phone, NULL);
+      TLS->callback.get_values (TLS, tgl_phone_number, "phone number:", 1, tgl_sign_in_phone, NULL);
     }
   } else {
     tgl_export_all_auth (TLS);
@@ -4303,7 +4306,7 @@ void tgl_login (struct tgl_state *TLS) {
       break;
     }
   }
-  
+
   if (!ok) {
     TLS->ev_login = TLS->timer_methods->alloc (TLS, check_authorized, NULL);
     TLS->timer_methods->insert (TLS->ev_login, 0.1);

--- a/tgl.h
+++ b/tgl.h
@@ -84,11 +84,22 @@ extern struct tgl_allocator tgl_allocator_release;
 extern struct tgl_allocator tgl_allocator_debug;
 struct tgl_state;
 
+enum tgl_value_type {
+    tgl_phone_number,           // user phone number
+    tgl_code,                   // telegram login code, or 'call' for phone call request
+    tgl_register_info,          // "Y/n" register?, first name, last name
+    tgl_new_password,           // new pass, confirm new pass
+    tgl_cur_and_new_password,   // curr pass, new pass, confirm new pass
+    tgl_cur_password,           // current pass
+    tgl_bot_hash
+};
+
 struct tgl_update_callback {
   void (*new_msg)(struct tgl_state *TLS, struct tgl_message *M);
   void (*marked_read)(struct tgl_state *TLS, int num, struct tgl_message *list[]);
   void (*logprintf)(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
-  void (*get_string)(struct tgl_state *TLS, const char *prompt, int flags, void (*callback)(struct tgl_state *TLS, const char *string, void *arg), void *arg);
+  void (*get_values)(struct tgl_state *TLS, enum tgl_value_type type, const char *prompt, int num_values,
+          void (*callback)(struct tgl_state *TLS, const char *string[], void *arg), void *arg);
   void (*logged_in)(struct tgl_state *TLS);
   void (*started)(struct tgl_state *TLS);
   void (*type_notification)(struct tgl_state *TLS, struct tgl_user *U, enum tgl_typing_status status);


### PR DESCRIPTION
Notice: API break

Current get_string callback forces a specific workflow for the library client, which is not suitable specially for GUI applications. For example, receiving users's first name, last name, and if the user wants to register at all can be requested from the user in a single GUI window; but current get_string doesn't allow it. 

Additionally, the prompt is dictated by the library, and the application doesn't know actually what information it is receiving from the user (unless it parses the prompt string, which is not a good idea).

Also, I removed 'flag' (which, AFAIK is used to specify if the user input should be visible or not), since now the library user actually knows what information it is receiving from the user so it can act accordingly.

The current implementation replaces get_string completely, so it breaks current clients. 
