### PR TITLE
Fix audio and video document downloads

### DIFF
--- a/queries.c
+++ b/queries.c
@@ -2486,7 +2486,13 @@ void tgl_do_load_document (struct tgl_state *TLS, struct tgl_document *V, void (
   D->dc = V->dc_id;
   D->name = 0;
   D->fd = -1;
-  D->type = CODE_input_document_file_location;
+  if (V->flags & TGLDF_VIDEO) {
+    D->type = CODE_input_video_file_location;
+  } else if (V->flags & TGLDF_AUDIO) {
+    D->type = CODE_input_audio_file_location;
+  } else {
+    D->type = CODE_input_document_file_location;
+  }
   if (V->mime_type) {
     char *r = tg_extension_by_mime (V->mime_type);
     if (r) {

--- a/structures.c
+++ b/structures.c
@@ -602,6 +602,8 @@ struct tgl_document *tglf_fetch_alloc_video_new (struct tgl_state *TLS, struct t
   
   tgl_document_insert (TLS, D);
 
+  D->flags = TGLDF_VIDEO;
+
   D->access_hash = DS_LVAL (DS_V->access_hash);
   D->user_id = DS_LVAL (DS_V->user_id);
   D->date = DS_LVAL (DS_V->date);


### PR DESCRIPTION
Downloading audio and video messages fails with "FILE_ID_INVALID".

This is caused by combining a video or audio file id with CODE_input_document_file_location, which the server doesn't accept. This patch uses the correct magic numbers for audio or video files.

This issue here is related: https://github.com/vysheng/tg/issues/472