### PR TITLE
Some fixes and improvents for file transfers

### DIFF
--- a/queries.c
+++ b/queries.c
@@ -2476,9 +2476,8 @@ void tgl_do_load_document_thumb (struct tgl_state *TLS, struct tgl_document *vid
   tgl_do_load_photo_size (TLS, &video->thumb, callback, callback_extra);
 }
 
-void tgl_do_load_document (struct tgl_state *TLS, struct tgl_document *V, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, const char *filename), void *callback_extra) {
+static void _tgl_do_load_document (struct tgl_state *TLS, struct tgl_document *V, struct download *D, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, const char *filename), void *callback_extra) {
   assert (V);
-  struct download *D = talloc0 (sizeof (*D));
   D->offset = 0;
   D->size = V->size;
   D->id = V->id;
@@ -2486,13 +2485,7 @@ void tgl_do_load_document (struct tgl_state *TLS, struct tgl_document *V, void (
   D->dc = V->dc_id;
   D->name = 0;
   D->fd = -1;
-  if (V->flags & TGLDF_VIDEO) {
-    D->type = CODE_input_video_file_location;
-  } else if (V->flags & TGLDF_AUDIO) {
-    D->type = CODE_input_audio_file_location;
-  } else {
-    D->type = CODE_input_document_file_location;
-  }
+  
   if (V->mime_type) {
     char *r = tg_extension_by_mime (V->mime_type);
     if (r) {
@@ -2500,6 +2493,30 @@ void tgl_do_load_document (struct tgl_state *TLS, struct tgl_document *V, void (
     }
   }
   load_next_part (TLS, D, callback, callback_extra);
+}
+
+void tgl_do_load_document (struct tgl_state *TLS, struct tgl_document *V, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, const char *filename), void *callback_extra) {
+  
+  struct download *D = talloc0 (sizeof (*D));
+  D->type = CODE_input_document_file_location;
+  
+  _tgl_do_load_document (TLS, V, D, callback, callback_extra);
+}
+
+void tgl_do_load_video (struct tgl_state *TLS, struct tgl_document *V, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, const char *filename), void *callback_extra) {
+
+  struct download *D = talloc0 (sizeof (*D));
+  D->type = CODE_input_video_file_location;
+  
+  _tgl_do_load_document (TLS, V, D, callback, callback_extra);
+}
+
+void tgl_do_load_audio (struct tgl_state *TLS, struct tgl_document *V, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, const char *filename), void *callback_extra) {
+  
+  struct download *D = talloc0 (sizeof (*D));
+  D->type = CODE_input_audio_file_location;
+
+  _tgl_do_load_document (TLS, V, D, callback, callback_extra);
 }
 
 void tgl_do_load_encr_document (struct tgl_state *TLS, struct tgl_encr_document *V, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, const char *filename), void *callback_extra) {

--- a/queries.c
+++ b/queries.c
@@ -1717,7 +1717,9 @@ static void _tgl_do_send_photo (struct tgl_state *TLS, tgl_peer_id_t to_id, cons
 void tgl_do_send_document (struct tgl_state *TLS, tgl_peer_id_t to_id, const char *file_name, const char *caption, int caption_len, unsigned long long flags, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, struct tgl_message *M), void *callback_extra) {
   if (flags & TGL_SEND_MSG_FLAG_DOCUMENT_AUTO) {
     char *mime_type = tg_mime_by_filename (file_name);
-    if (!memcmp (mime_type, "image/", 6)) {
+    if (strcmp (mime_type, "image/gif") == 0) {
+      flags |= TGL_SEND_MSG_FLAG_DOCUMENT_ANIMATED;
+    } else if (!memcmp (mime_type, "image/", 6)) {
       flags |= TGL_SEND_MSG_FLAG_DOCUMENT_PHOTO;
     } else if (!memcmp (mime_type, "video/", 6)) {
       flags |= TGLDF_VIDEO;

--- a/structures.c
+++ b/structures.c
@@ -956,12 +956,12 @@ void tglf_fetch_message_media_new (struct tgl_state *TLS, struct tgl_message_med
     break;
   case CODE_message_media_video:
   case CODE_message_media_video_l27:
-    M->type = tgl_message_media_document;
+    M->type = tgl_message_media_video;
     M->document = tglf_fetch_alloc_video_new (TLS, DS_MM->video);
     M->caption = DS_STR_DUP (DS_MM->caption);
     break;
   case CODE_message_media_audio:
-    M->type = tgl_message_media_document;
+    M->type = tgl_message_media_audio;
     M->document = tglf_fetch_alloc_audio_new (TLS, DS_MM->audio);
     break;
   case CODE_message_media_document:
@@ -1763,6 +1763,8 @@ void tgls_free_message_media (struct tgl_state *TLS, struct tgl_message_media *M
     tfree_str (M->last_name);
     return;
   case tgl_message_media_document:
+  case tgl_message_media_video:
+  case tgl_message_media_audio:
     tgls_free_document (TLS, M->document);
     return;
   case tgl_message_media_unsupported:

--- a/tgl-layout.h
+++ b/tgl-layout.h
@@ -136,8 +136,6 @@ struct tgl_dc {
 enum tgl_message_media_type {
   tgl_message_media_none,
   tgl_message_media_photo,
-  //tgl_message_media_video,
-  //tgl_message_media_audio,
   tgl_message_media_document,
   tgl_message_media_geo,
   tgl_message_media_contact,
@@ -147,7 +145,9 @@ enum tgl_message_media_type {
   //tgl_message_media_audio_encr,
   tgl_message_media_document_encr,
   tgl_message_media_webpage,
-  tgl_message_media_venue
+  tgl_message_media_venue,
+  tgl_message_media_video,
+  tgl_message_media_audio
 };
 
 enum tgl_message_action_type {

--- a/tgl.h
+++ b/tgl.h
@@ -568,6 +568,9 @@ void tgl_do_load_photo (struct tgl_state *TLS, struct tgl_photo *photo, void (*c
 void tgl_do_load_encr_document (struct tgl_state *TLS, struct tgl_encr_document *V, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, const char *file_name), void *callback_extra);
 void tgl_do_load_document (struct tgl_state *TLS, struct tgl_document *V, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, const char *file_name), void *callback_extra);
 void tgl_do_load_document_thumb (struct tgl_state *TLS, struct tgl_document *video, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, const char *file_name), void *callback_extra);
+void tgl_do_load_video (struct tgl_state *TLS, struct tgl_document *V, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, const char *filename), void *callback_extra);
+void tgl_do_load_audio (struct tgl_state *TLS, struct tgl_document *V, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, const char *filename), void *callback_extra);
+
 
 // loads file by location. Use only for small files!
 void tgl_do_load_file_location (struct tgl_state *TLS, struct tgl_file_location *FL, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, const char *file_name), void *callback_extra);


### PR DESCRIPTION
### 1. Fixes a bug that caused video/audio file downloads to fail when communicating with other libtgl-based clients

Apparently Telegram differs between the media formats solely based on InputMedia type and not based on the attributes. I tried to create a patch that does not change existing method signatures and structs to keep backwards-compatibility, but allows downloading InputMediaVideo and InputMediaAudio using two new methods tgl_do_load_audio and tgl_do_load_video.

- It is be possible to trigger this bug when communicating with third-party clients that add the VIDEO/AUDIO-attributes to document uploads. The official iOS, Android and Desktop Apps do not add this attribute, but receiving a download by other clients using libtgl may cause this.

- This bug was intruduced by my previous pull request, that differs between Input types based on those attribute flags.

### 2. Improve support for sending GIFs.

Auto-detect gifs in tgl_do_send_document and add the appropriate message flag. As a result, the official Telegram clients adds will animate GIFs that are sent by libtgl :)