### PR TITLE
fix #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h>

### DIFF
--- a/tgl-net.c
+++ b/tgl-net.c
@@ -30,7 +30,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/socket.h>
 #include <errno.h>
 #include <stdio.h>


### PR DESCRIPTION
 <sys/fcntl.h> to <fcntl.h> in OpenWRT build