### PR TITLE
Add-in forgotten objects.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -57,10 +57,10 @@ ${TGL_OBJECTS_AUTO}: ${OBJ}/auto/%.o: ${AUTO}/%.c | create_dirs
 	${CC} ${INCLUDE} ${COMPILE_FLAGS} -iquote ${srcdir}/tgl -c -MP -MD -MF ${DEP}/$*.d -MQ ${OBJ}/$*.o -o $@ $<
 
 ${LIB}/libtgl.a: ${TGL_OBJECTS} ${COMMON_OBJECTS} ${TGL_OBJECTS_AUTO}
-	rm -f $@ && ar ruv $@ ${TGL_OBJECTS} ${COMMON_OBJECTS}
+	rm -f $@ && ar ruv $@ $^
 
 ${LIB}/libtgl.so: ${TGL_OBJECTS} ${COMMON_OBJECTS} ${TGL_OBJECTS_AUTO}
-	${CC} -shared -o $@ ${TGL_OBJECTS} ${COMMON_OBJECTS} ${LINK_FLAGS}
+	${CC} -shared -o $@ $^ ${LINK_FLAGS}
 
 ${EXE}/generate: ${GENERATE_OBJECTS} ${COMMON_OBJECTS}
 	${CC} ${GENERATE_OBJECTS} ${COMMON_OBJECTS} ${LINK_FLAGS} -o $@


### PR DESCRIPTION
In particular, ${TGL_OBJECTS_AUTO} used to be skipped,
meaning lots of missing symbols in libtgl.{a,so}.