### PR TITLE
Avoid using EPROTO on BSD.

### DIFF
--- a/errors
+++ b/errors
@@ -1,6 +1,6 @@
 type of errors that tgl can set:
 
-EPROTO: server returned error for query. Some kinds of error (such as FLOOD_WAIT) tgl can handle by itself, but others it can not. In most cases it means bug in tgl or invalid parameter supplied to method (such as message id).
+EPROTO: server returned error for query. Some kinds of error (such as FLOOD_WAIT) tgl can handle by itself, but others it can not. In most cases it means bug in tgl or invalid parameter supplied to method (such as message id). On BSD, EPROTO is not defined. Whenever EPROTO is not #define'd, tgl uses EIO instead.
 
 EINVAL: tgl detected invalid argument supplied before sending query to server. For example user instead of chat or bad msg id. 
 

--- a/queries.c
+++ b/queries.c
@@ -61,6 +61,12 @@
 #include "mtproto-utils.h"
 #include "tgl-methods-in.h"
 
+#ifndef EPROTO
+// BSD doesn't define EPROTO, even though it is POSIX:
+// https://lists.freebsd.org/pipermail/freebsd-standards/2003-June/000124.html
+#define EPROTO EIO
+#endif
+
 #define sha1 SHA1
 
 #ifndef PATH_MAX


### PR DESCRIPTION
Failing example: http://pastebin.com/raw.php?i=CAQscmAZ

I didn't find this bug, credits for that go to Alex.

On a side note, BSD-users still have to work around some strangeness with libwebp.