### PR TITLE
Add auto objects to static library

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -57,7 +57,7 @@ ${TGL_OBJECTS_AUTO}: ${OBJ}/auto/%.o: ${AUTO}/%.c | create_dirs
 	${CC} ${INCLUDE} ${COMPILE_FLAGS} -iquote ${srcdir}/tgl -c -MP -MD -MF ${DEP}/$*.d -MQ ${OBJ}/$*.o -o $@ $<
 
 ${LIB}/libtgl.a: ${TGL_OBJECTS} ${COMMON_OBJECTS} ${TGL_OBJECTS_AUTO}
-	rm -f $@ && ar ruv $@ ${TGL_OBJECTS} ${COMMON_OBJECTS}
+	rm -f $@ && ar ruv $@ $^
 
 ${LIB}/libtgl.so: ${TGL_OBJECTS} ${COMMON_OBJECTS} ${TGL_OBJECTS_AUTO}
 	${CC} -shared -o $@ ${TGL_OBJECTS} ${COMMON_OBJECTS} ${LINK_FLAGS}


### PR DESCRIPTION
I'm not sure if this change is correct here, I guess so because you use something like this in:
https://github.com/vysheng/tg/blob/master/Makefile.tgl#L28

I'm working in a rust wrapper for this library and I wasn't able to run anything without this change, due to missing symbols.

I'm also not sure if this change should be made to the shared library as well.

Sorry if the change is not correct in advance :P