### PR TITLE
Revert "delete config.h on make clean"

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -91,5 +91,5 @@ ${EXE}/dump-tl-file: ${OBJ}/auto/auto.o ${TLD_OBJECTS}
 	${CC} ${OBJ}/auto/auto.o ${TLD_OBJECTS} ${LINK_FLAGS} -o $@
 
 clean:
-	rm -rf ${DIR_LIST} config.h config.log config.status > /dev/null || echo "all clean"
+	rm -rf ${DIR_LIST} config.log config.status > /dev/null || echo "all clean"
 


### PR DESCRIPTION
This reverts commit e092552313bcb97755c550552baa62b531b95203.

- Either add a rule that *RE*generates config.h (which depends on the
  arguments initially given to ./configure, which are saved in
  config.status, but that file is deleted, too, so this doesn't work).
- Or simply don't delete config.h.