### PR TITLE
Add 'extern' to tgl_allocator declaration in tools.h to prevent multi…

### DIFF
--- a/tools.h
+++ b/tools.h
@@ -40,7 +40,7 @@
 #define tsnprintf tgl_snprintf
 
 
-struct tgl_allocator *tgl_allocator;
+extern struct tgl_allocator *tgl_allocator;
 double tglt_get_double_time (void);
 
 int tgl_inflate (void *input, int ilen, void *output, int olen);


### PR DESCRIPTION
…ple definition error when used as static library
