### PR TITLE
Avoid http where easy, check for correct gcrypt version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Clone GitHub Repository
 Install libs: openssl, zlib
 if you want to use provided net/timers then install libevent and add --enable-libevent key to configure
 
+You can also avoid the OpenSSL dependency: Install gcrypt (>= 1.60, Debian derivates know it as "libgcrypt20-dev"), and add --disable-openssl to openssl.
+
 Then,
 
-     autoheader
-     autoconf
      ./configure
      make
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ This is library that handles telegram api and protocol.
 
 ### API, Protocol documentation
 
-Documentation for Telegram API is available here: http://core.telegram.org/api
+Documentation for Telegram API is available here: https://core.telegram.org/api
 
-Documentation for MTproto protocol is available here: http://core.telegram.org/mtproto
+Documentation for MTproto protocol is available here: https://core.telegram.org/mtproto
 
 ### Installation
 

--- a/configure
+++ b/configure
@@ -3273,9 +3273,9 @@ if test "${enable_openssl+set}" = set; then :
 
 $as_echo "#define TGL_AVOID_OPENSSL 1" >>confdefs.h
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gcry_md_open in -lgcrypt" >&5
-$as_echo_n "checking for gcry_md_open in -lgcrypt... " >&6; }
-if ${ac_cv_lib_gcrypt_gcry_md_open+:} false; then :
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gcry_mpi_snatch in -lgcrypt" >&5
+$as_echo_n "checking for gcry_mpi_snatch in -lgcrypt... " >&6; }
+if ${ac_cv_lib_gcrypt_gcry_mpi_snatch+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
@@ -3289,32 +3289,37 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #ifdef __cplusplus
 extern "C"
 #endif
-char gcry_md_open ();
+char gcry_mpi_snatch ();
 int
 main ()
 {
-return gcry_md_open ();
+return gcry_mpi_snatch ();
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_gcrypt_gcry_md_open=yes
+  ac_cv_lib_gcrypt_gcry_mpi_snatch=yes
 else
-  ac_cv_lib_gcrypt_gcry_md_open=no
+  ac_cv_lib_gcrypt_gcry_mpi_snatch=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_gcrypt_gcry_md_open" >&5
-$as_echo "$ac_cv_lib_gcrypt_gcry_md_open" >&6; }
-if test "x$ac_cv_lib_gcrypt_gcry_md_open" = xyes; then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_gcrypt_gcry_mpi_snatch" >&5
+$as_echo "$ac_cv_lib_gcrypt_gcry_mpi_snatch" >&6; }
+if test "x$ac_cv_lib_gcrypt_gcry_mpi_snatch" = xyes; then :
   cat >>confdefs.h <<_ACEOF
 #define HAVE_LIBGCRYPT 1
 _ACEOF
 
   LIBS="-lgcrypt $LIBS"
+
+else
+
+      echo "Need libgcrypt >= 1.60"
+      exit -1
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,11 @@ AC_ARG_ENABLE(openssl,[  --disable-openssl	  disables OpenSSL, and don't link ag
   [ 
   if test "x$enableval" = "xno" ; then    
 	AC_DEFINE([TGL_AVOID_OPENSSL],[1],[avoid OpenSSL entirely, use libgcrypt instead (this can't read *.pub files, though.)])
-    AC_CHECK_LIB([gcrypt], [gcry_md_open])
+    dnl FIXME: Should replace "echo & exit -1" with AC_ERR_MSG or something similar
+    AC_CHECK_LIB([gcrypt], [gcry_mpi_snatch], [], [
+      echo "Need libgcrypt >= 1.60"
+      exit -1
+    ])
   else
     # Don't be annoying, so don't inform the user about --disable-openssl
     AX_CHECK_OPENSSL(,[AC_MSG_ERROR([No openssl found.])])

--- a/crypto/meta.h
+++ b/crypto/meta.h
@@ -1,3 +1,23 @@
+/* 
+    This file is part of tgl-library
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+    Copyright Ben Wiederhake 2015
+*/
+
 #ifndef CRYPTO_META_H_
 #define CRYPTO_META_H_
 
@@ -23,7 +43,7 @@
  *
  * The standard doesn't explicitly allow it, but there's a pretty good argument
  * that casting ptr-to-some-struct to ptr-to-other-struct is *probably* okay for
- * most compilers: http://stackoverflow.com/a/8702750/3070326
+ * most compilers: https://stackoverflow.com/a/8702750/3070326
  */
 #define TGLC_WRAPPER_ASSOC(NAME,CORE)                                          \
   static TGLC_ ## NAME *wrap_ ## NAME (const CORE *p)                          \

--- a/mime.types
+++ b/mime.types
@@ -9,7 +9,7 @@
 # content languages and encodings, so choose them carefully.
 #
 # Internet media types should be registered as described in RFC 4288.
-# The registry is at <http://www.iana.org/assignments/media-types/>.
+# The registry is at <https://www.iana.org/assignments/media-types/media-types.xhtml>.
 #
 # MIME type (lowercased)			Extensions
 # ============================================	==========


### PR DESCRIPTION
"Tails" is one example for an OS that still ships an outdated version of gcrypt (package "libgcrypt11-dev").