### PR TITLE
make generate work on windows

### DIFF
--- a/generate.c
+++ b/generate.c
@@ -2951,6 +2951,27 @@ void sig_abrt_handler (int signum __attribute__ ((unused))) {
   exit (EXIT_FAILURE);
 }
 
+static int
+read_all(int fd, void *buf, size_t len)
+{
+	unsigned int rs = 0;
+	while(rs < len)
+	{
+		int rval = read(fd, buf + rs, len - rs);
+		if (rval == 0)
+			break;
+		if (rval < 0)
+			return rval;
+
+		rs += rval;
+	}
+	return rs;
+}
+
+#ifndef O_BINARY 
+#define O_BINARY 0 
+#endif
+
 int main (int argc, char **argv) {
   signal (SIGSEGV, sig_segv_handler);
   signal (SIGABRT, sig_abrt_handler);
@@ -2977,12 +2998,12 @@ int main (int argc, char **argv) {
     usage ();
   }
 
-  int fd = open (argv[optind], O_RDONLY);
+  int fd = open (argv[optind], O_RDONLY | O_BINARY);
   if (fd < 0) {
     fprintf (stderr, "Can not open file '%s'. Error %m\n", argv[optind]);
     exit (1);
   }
-  buf_size = read (fd, buf, (1 << 20));
+  buf_size = read_all (fd, buf, (1 << 20));
   if (fd == (1 << 20)) {
     fprintf (stderr, "Too big tlo file\n");
     exit (2);


### PR DESCRIPTION
read() does not guarantee that the number of bytes requested will be read, so read in a loop until we get EOF
Use binary file reads to not translate whitespace 

Without these changes running generate.exe always results in the error 

File: generate.c, Line 126

Expression: buf_ptr < buf_end
