### PR TITLE
Improve history handling

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -97,5 +97,10 @@ distclean:
 	rm -rf ${DIR_LIST} config.h config.log config.status
 
 mime-types.c: mime.types
-# xxd is usually packaged with vim-common
-	xxd -i mime.types > mime-types.c
+	@echo xxd -i mime.types > mime-types.c
+	@if command -v xxd >/dev/null 2>&1 ; then \
+		xxd -i mime.types > mime-types.c ; \
+	else \
+		echo "# No xxd installed!  Trying to skip ..." ; \
+		test -r $@ ; \
+	fi

--- a/Makefile.in
+++ b/Makefile.in
@@ -97,6 +97,5 @@ distclean:
 	rm -rf ${DIR_LIST} config.h config.log config.status
 
 mime-types.c: mime.types
-	@echo "// DO NOT EDIT! SEE MAKE-TARGET 'gen-mime-types'" > mime-types.c
 # xxd is usually packaged with vim-common
-	xxd -i mime.types >> mime-types.c
+	xxd -i mime.types > mime-types.c

--- a/auto-static-autocomplete.c
+++ b/auto-static-autocomplete.c
@@ -43,6 +43,7 @@ int tglf_extf_autocomplete (struct tgl_state *TLS, const char *text, int text_le
 #ifdef DISABLE_EXTF
   (void) free_vars_to_be_freed;
   assert (0);
+  return 0;
 #else
   if (index == -1) {
     buffer_pos = data;

--- a/auto-static-fetch.c
+++ b/auto-static-fetch.c
@@ -106,6 +106,7 @@ static void print_offset (void) {
 char *tglf_extf_fetch (struct tgl_state *TLS, struct paramed_type *T) {
 #ifdef DISABLE_EXTF
   assert (0);
+  return 0;
 #else
   out_buf_pos = 0;
   if (fetch_type_any (T) < 0) { return 0; }

--- a/auto-static-store.c
+++ b/auto-static-store.c
@@ -253,6 +253,7 @@ void tgl_paramed_type_free (struct paramed_type *P);
 struct paramed_type *tglf_extf_store (struct tgl_state *TLS, const char *data, int data_len) { 
 #ifdef DISABLE_EXTF
   assert (0);
+  return 0;
 #else
   buffer_pos = (char *)data;
   buffer_end = (char *)(data + data_len);

--- a/crypto/err.h
+++ b/crypto/err.h
@@ -25,4 +25,10 @@
 
 void TGLC_err_print_errors_fp (FILE *fp);
 
+// Don't want to include tgl.h just for this
+struct tgl_state;
+
+// Init crypto backend, log to TLS
+int TGLC_init (struct tgl_state *TLS);
+
 #endif

--- a/crypto/err_openssl.c
+++ b/crypto/err_openssl.c
@@ -24,15 +24,17 @@
 
 #include <openssl/err.h>
 
+#include "../tgl.h"
+#include "../tgl-inner.h"
 #include "err.h"
 
 void TGLC_err_print_errors_fp (FILE *fp) {
   ERR_print_errors_fp (fp);
 }
 
-int TGLC_init (void) {
+int TGLC_init (struct tgl_state *TLS) {
   // Doesn't seem to need any initialization.
-  vlogprintf (E_DEBUG, "Init OpenSSL (no-op)\n");
+  vlogprintf (6, "Init OpenSSL (no-op)\n");
   return !0;
 }
 

--- a/crypto/err_openssl.c
+++ b/crypto/err_openssl.c
@@ -30,4 +30,10 @@ void TGLC_err_print_errors_fp (FILE *fp) {
   ERR_print_errors_fp (fp);
 }
 
+int TGLC_init (void) {
+  // Doesn't seem to need any initialization.
+  vlogprintf (E_DEBUG, "Init OpenSSL (no-op)\n");
+  return !0;
+}
+
 #endif

--- a/crypto/err_openssl.c
+++ b/crypto/err_openssl.c
@@ -35,7 +35,7 @@ void TGLC_err_print_errors_fp (FILE *fp) {
 int TGLC_init (struct tgl_state *TLS) {
   // Doesn't seem to need any initialization.
   vlogprintf (6, "Init OpenSSL (no-op)\n");
-  return !0;
+  return 0;
 }
 
 #endif

--- a/generate.c
+++ b/generate.c
@@ -2307,7 +2307,6 @@ void gen_skip_source (void) {
   printf ("#include <assert.h>\n");
 
   printf ("#include \"auto/auto-skip.h\"\n");
-  printf ("#include \"auto-static-skip.c\"\n");
   printf ("#include \"mtproto-common.h\"\n");
 
   int i, j;

--- a/mtproto-client.c
+++ b/mtproto-client.c
@@ -678,11 +678,12 @@ static double get_server_time (struct tgl_dc *DC) {
 
 static long long generate_next_msg_id (struct tgl_state *TLS, struct tgl_dc *DC, struct tgl_session *S) {
   long long next_id = (long long) (get_server_time (DC) * (1LL << 32)) & -4;
-  if (next_id <= S->last_msg_id) {
-    next_id = S->last_msg_id  += 4;
+  if (next_id <= TLS->last_msg_id) {
+    next_id = TLS->last_msg_id  += 4;
   } else {
-    S->last_msg_id = next_id;
+    TLS->last_msg_id = next_id;
   }
+  S->last_msg_id = next_id; // See tglmp_encrypt_send_message
   return next_id;
 }
 
@@ -754,7 +755,7 @@ long long tglmp_encrypt_send_message (struct tgl_state *TLS, struct connection *
   assert (l > 0);
   rpc_send_message (TLS, c, &enc_msg, l + UNENCSZ);
 
-  return S->last_msg_id;
+  return S->last_msg_id; // Pray that this was set by generate_next_msg_id somehow
 }
 
 int tglmp_encrypt_inner_temp (struct tgl_state *TLS, struct connection *c, int *msg, int msg_ints, int useful, void *data, long long msg_id) {

--- a/mtproto-utils.c
+++ b/mtproto-utils.c
@@ -98,7 +98,6 @@ static unsigned long long BN2ull (TGLC_bn *b) {
   if (sizeof (unsigned long) == 8) {
     return TGLC_bn_get_word (b);
   } else if (sizeof (unsigned long long) == 8) {
-    assert (0); // As long as nobody ever uses this code, assume it is broken.
     unsigned long long tmp;
     /* Here be dragons, but it should be okay due to be64toh */
     TGLC_bn_bn2bin (b, (unsigned char *) &tmp);
@@ -112,8 +111,7 @@ static void ull2BN (TGLC_bn *b, unsigned long long val) {
   if (sizeof (unsigned long) == 8 || val < (1ll << 32)) {
     TGLC_bn_set_word (b, val);
   } else if (sizeof (unsigned long long) == 8) {
-    assert (0); // As long as nobody ever uses this code, assume it is broken.
-    htobe64(val);
+    val = htobe64(val);
     /* Here be dragons, but it should be okay due to htobe64 */
     TGLC_bn_bin2bn ((unsigned char *) &val, 8, b);
   } else {

--- a/queries.c
+++ b/queries.c
@@ -1496,7 +1496,7 @@ static int get_history_on_answer (struct tgl_state *TLS, struct query *q, void *
   assert (E->limit >= 0);
 
 
-  if (E->limit <= 0 || DS_MM->magic == CODE_messages_messages || DS_MM->magic == CODE_messages_channel_messages) {
+  if (E->limit <= 0 || DS_MM->magic == CODE_messages_messages) {
     if (q->callback) {
       ((void (*)(struct tgl_state *TLS, void *, int, int, struct tgl_message **))q->callback) (TLS, q->callback_extra, 1, E->list_offset, E->ML);
     }

--- a/queries.c
+++ b/queries.c
@@ -704,7 +704,7 @@ static char *process_html_text (struct tgl_state *TLS, const char *text, int tex
         while (pp < text_len && text[pp] != '"') {
           pp ++;
         }
-        if (pp == text_len || pp == text_len - 1 || text[pp + 1] != '>') {
+        if (pp == text_len || pp == text_len - 1) {
           tgl_set_query_error (TLS, EINVAL, "<a> tag did not close");
           tfree (new_text, 2 * text_len + 1);
           return NULL;
@@ -730,7 +730,10 @@ static char *process_html_text (struct tgl_state *TLS, const char *text, int tex
         memcpy (r + 1, text + p + 9, len);
         memset (r + 1 + len, 0, (-len-1) & 3);
 
-        p = pp + 1;
+        while (pp < text_len && text[pp] != '>') {
+          pp ++;
+        }
+        p = pp;
         continue;
       }
       if (text_len - p >= 4 && !ascii_cmp_nocase (text + p, "</a>", 4)) {

--- a/structures.c
+++ b/structures.c
@@ -2071,7 +2071,7 @@ void tgls_free_message_media (struct tgl_state *TLS, struct tgl_message_media *M
   case tgl_message_media_geo:
     return;
   case tgl_message_media_photo:
-    tgls_free_photo (TLS, M->photo);
+    if (M->photo) { tgls_free_photo (TLS, M->photo); }
     if (M->caption) { tfree_str (M->caption); }
     M->photo = NULL;
     return;

--- a/structures.c
+++ b/structures.c
@@ -2570,11 +2570,22 @@ void tgls_free_message_gw (struct tgl_message *M, void *TLS) {
   tgls_free_message (TLS, M);
 }
 
+void tgls_remove_message_gw (struct tgl_state *TLS, struct tgl_message *M) {
+  if (tree_lookup_message (TLS->message_unsent_tree, M)) {
+      tglm_message_remove_unsent (TLS, M);
+  }
+}
+
+void tgls_remove_and_free_message_gw (struct tgl_message *M, void *TLS) {
+  tgls_remove_message_gw (TLS, M);
+  tgls_free_message (TLS, M);
+}
+
 void tgl_free_all (struct tgl_state *TLS) {
   tree_act_ex_peer (TLS->peer_tree, tgls_free_peer_gw, TLS);
   TLS->peer_tree = tree_clear_peer (TLS->peer_tree);
   TLS->peer_by_name_tree = tree_clear_peer_by_name (TLS->peer_by_name_tree);
-  tree_act_ex_message (TLS->message_tree, tgls_free_message_gw, TLS);
+  tree_act_ex_message (TLS->message_tree, tgls_remove_and_free_message_gw, TLS);
   TLS->message_tree = tree_clear_message (TLS->message_tree);
   tree_act_ex_message (TLS->message_unsent_tree, tgls_free_message_gw, TLS);
   TLS->message_unsent_tree = tree_clear_message (TLS->message_unsent_tree);

--- a/tgl-layout.h
+++ b/tgl-layout.h
@@ -144,7 +144,7 @@ enum tgl_dc_state {
 struct tgl_session {
   struct tgl_dc *dc;
   long long session_id;
-  long long last_msg_id;
+  long long last_msg_id; // See tglmp_encrypt_send_message
   int seq_no;
   int received_messages;
   struct connection *c;

--- a/tgl-queries.h
+++ b/tgl-queries.h
@@ -236,6 +236,12 @@ void tgl_do_messages_mark_read (struct tgl_state *TLS, tgl_peer_id_t id, int max
 // also marks messages from this chat as read
 void tgl_do_get_history (struct tgl_state *TLS, tgl_peer_id_t id, int offset, int limit, int offline_mode, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, int size, struct tgl_message *list[]), void *callback_extra);
 
+// like tgl_do_get_history, but will fetch any messages between *min_id* and *max_id*
+// when *limit* is too small, the older messages will not be displayed despite being bigger than *min_id*
+// when *max_id* is 0, all messages newer than *min_id* are fetched
+// when *min_id* is 0, all messages older than *max_id* are fetched
+void tgl_do_get_history_range (struct tgl_state *TLS, tgl_peer_id_t id, int min_id, int max_id, int limit, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, int size, struct tgl_message *list[]), void *callback_extra);
+
 // sends typing event to chat
 // set status=tgl_typing_typing for default typing event
 void tgl_do_send_typing (struct tgl_state *TLS, tgl_peer_id_t id, enum tgl_typing_status status, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success), void *callback_extra);

--- a/tgl.c
+++ b/tgl.c
@@ -22,6 +22,7 @@
 #include "config.h"
 #endif
 
+#include "crypto/err.h"
 #include "crypto/rsa_pem.h"
 #include "tgl.h"
 #include "tools.h"
@@ -82,10 +83,14 @@ int tgl_init (struct tgl_state *TLS) {
   TLS->message_list.next_use = &TLS->message_list;
   TLS->message_list.prev_use = &TLS->message_list;
 
+  if (TGLC_init (TLS) != 0) {
+    return -1;
+  }
+
   if (tglmp_on_start (TLS) < 0) {
     return -1;
   }
-  
+
   if (!TLS->app_id) {
     TLS->app_id = TG_APP_ID;
     TLS->app_hash = tstrdup (TG_APP_HASH);

--- a/tgl.h
+++ b/tgl.h
@@ -264,6 +264,7 @@ struct tgl_state {
   int is_bot;
 
   int last_temp_id;
+  long long last_msg_id;
 };
 #pragma pack(pop)
 //extern struct tgl_state tgl_state;


### PR DESCRIPTION
Allow fetching message history between max_id and min_id in a new api call. This is needed for fetching channel history when the amount of required amount of messages is unknown. 

Additionally allow fetching more than 100 channel messages. I don't know why it was disabled in the first place, but I tested it thoroughly and the history function doesn't have any issue handling the channel return type CODE_messages_channel_messages.

A last change is to use less confusing naming in get_history_extra struct, offset_id is now actually called offset_id except of max_id.
