### PR TITLE
Fixed error in set_profile_picture command: FAIL: 71: RPC_CALL_FAIL 4…

### DIFF
--- a/queries.c
+++ b/queries.c
@@ -1863,7 +1863,6 @@ static void send_avatar_end (struct tgl_state *TLS, struct send_file *f, void *c
     break;
   case TGL_PEER_USER:
     out_int (CODE_photos_upload_profile_photo);
-    out_int (CODE_photos_upload_profile_photo);
     break;
   case TGL_PEER_CHANNEL:
     out_int (CODE_channels_edit_photo);


### PR DESCRIPTION
Duplicated line: 
out_int (CODE_photos_upload_profile_photo);

was causing error: 
"FAIL: 71: RPC_CALL_FAIL 400: FILE_ID_INVALID"

when attempting to set a profile photo.
