### PR TITLE
 Fixed error when loading an image of a expired forwarded message(image) originated from a bot (Empty Message)

### DIFF
--- a/queries.c
+++ b/queries.c
@@ -3301,6 +3301,13 @@ void tgl_do_load_file_location (struct tgl_state *TLS, struct tgl_file_location 
 }
 
 void tgl_do_load_photo (struct tgl_state *TLS, struct tgl_photo *photo, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, const char *filename), void *callback_extra) {
+  if (!photo) {
+    tgl_set_query_error (TLS, EINVAL, "Bad photo (invalid)");
+    if (callback) {
+      callback (TLS, callback_extra, 0, 0);
+    }
+    return;
+  }
   if (!photo->sizes_num) {
     tgl_set_query_error (TLS, EINVAL, "Bad photo (no photo sizes");
     if (callback) {


### PR DESCRIPTION
I'm using [tvdstaaij/telegram-history-dump](https://github.com/tvdstaaij/telegram-history-dump) to archive my chats, and when it hits a forwarded message of a bot message that has expired [vysheng/tg](https://github.com/vysheng/tg) will crash with the error below when calling [tgl_do_load_photo](https://github.com/vysheng/tgl/blob/master/queries.c#L3303) on an ID of an Empty Message. The empty message still has the contents of the forwarded message when you request the history which is the issue causing this. This fix works seamlessly across the various clients.

Should this fix also be applied other tgl_do_load_(media type here)?

Crash on  [vysheng/tg](https://github.com/vysheng/tg) when doing load_photo on an Empty Message:

> SIGNAL received
> hbin/telegram-cli(print_backtrace+0x2f)[0x46ef1f]
> bin/telegram-cli(termination_signal_handler+0x64)[0x46efb4]
> /lib/x86_64-linux-gnu/libc.so.6(+0x354a0)[0x7fbe9abd44a0]
> bin/telegram-cli(tgl_do_load_photo+0x0)[0x4a0e80]
> bin/telegram-cli(interpreter_ex+0x970)[0x478e50]
> bin/telegram-cli[0x46f501]
> /usr/lib/x86_64-linux-gnu/libevent-2.0.so.5(+0x188da)[0x7fbe9c0a38da]
> /usr/lib/x86_64-linux-gnu/libevent-2.0.so.5(event_base_loop+0x7fc)[0x7fbe9c098a0c]
> bin/telegram-cli(net_loop+0xa7)[0x470557]
> bin/telegram-cli(loop+0x183)[0x4718c3]
> bin/telegram-cli(main+0x2e5)[0x46d745]
> /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7fbe9abbf830]
> bin/telegram-cli(_start+0x29)[0x46d859]

Example of an Empty Message:
![Empty Message](http://i.imgur.com/uZ1bmiF.png)

Example of an Empty Message in history:
exactly the same as a forwarded message(image)
