### PR TITLE
Fix bug with getting messages from channels

### DIFF
--- a/queries.c
+++ b/queries.c
@@ -1576,21 +1576,13 @@ void tgl_do_get_local_history (struct tgl_state *TLS, tgl_peer_id_t id, int offs
 
 static void _tgl_do_get_history (struct tgl_state *TLS, struct get_history_extra *E, void (*callback)(struct tgl_state *TLS,void *callback_extra, int success, int size, struct tgl_message *list[]), void *callback_extra) {
   clear_packet ();
-  tgl_peer_t *C = tgl_peer_get (TLS, E->id);
-  if (tgl_get_peer_type (E->id) != TGL_PEER_CHANNEL || (C && (C->flags & TGLCHF_MEGAGROUP))) {
-    out_int (CODE_messages_get_history);
-    out_peer_id (TLS, E->id);
-  } else {    
-    out_int (CODE_channels_get_important_history);
-    
-    out_int (CODE_input_channel);
-    out_int (tgl_get_peer_id (E->id));
-    out_long (E->id.access_hash);
-  }
-  out_int (E->max_id);
+  out_int (CODE_messages_get_history);
+  out_peer_id (TLS, E->id);
+  out_int (0);
+  out_int (0);
   out_int (E->offset);
   out_int (E->limit);
-  out_int (0);
+  out_int (E->max_id);
   out_int (0);
   tglq_send_query (TLS, TLS->DC_working, packet_ptr - packet_buffer, packet_buffer, &get_history_methods, E, callback, callback_extra);
 }

--- a/scheme.tl
+++ b/scheme.tl
@@ -619,7 +619,7 @@ contacts.resolveUsername#f93ccba3 username:string = contacts.ResolvedPeer;
 
 messages.getMessages#4222fa74 id:Vector<int> = messages.Messages;
 messages.getDialogs#6b47f94d offset_date:int offset_id:int offset_peer:InputPeer limit:int = messages.Dialogs;
-messages.getHistory#8a8ec2da peer:InputPeer offset_id:int add_offset:int limit:int max_id:int min_id:int = messages.Messages;
+messages.getHistory#afa92846 peer:InputPeer offset_id:int offset_date:int add_offset:int limit:int max_id:int min_id:int = messages.Messages;
 messages.search#d4569248 flags:# important_only:flags.0?true peer:InputPeer q:string filter:MessagesFilter min_date:int max_date:int offset:int max_id:int limit:int = messages.Messages;
 messages.readHistory#e306d3a peer:InputPeer max_id:int = messages.AffectedMessages;
 messages.deleteHistory#b7c13bd9 peer:InputPeer max_id:int = messages.AffectedHistory;


### PR DESCRIPTION
When you try to get messages from channel with offset you get {'result': 'FAIL', 'error': 'RPC_CALL_FAIL 400: OFFSET_INVALID', 'error_code': 71}. 

I fixed it by using another command code (from here: [scheme.tl](https://github.com/telegramdesktop/tdesktop/blob/0d7af044e91452f7bd0db39c6eb9316e16d6071e/Telegram/SourceFiles/mtproto/scheme.tl), it's official desktop client repository)
