### PR TITLE
Fix out-of-source compile: fix path of config.h in crypto/

### DIFF
--- a/crypto/aes.h
+++ b/crypto/aes.h
@@ -23,7 +23,7 @@
 
 #include <stddef.h> /* size_t */
 
-#include "../config.h"
+#include "config.h"
 
 typedef struct TGLC_aes_key {
   char _dummy[

--- a/crypto/aes_altern.c
+++ b/crypto/aes_altern.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifdef TGL_AVOID_OPENSSL
 

--- a/crypto/aes_openssl.c
+++ b/crypto/aes_openssl.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifndef TGL_AVOID_OPENSSL
 

--- a/crypto/bn_altern.c
+++ b/crypto/bn_altern.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifdef TGL_AVOID_OPENSSL
 

--- a/crypto/bn_openssl.c
+++ b/crypto/bn_openssl.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifndef TGL_AVOID_OPENSSL
 

--- a/crypto/err_altern.c
+++ b/crypto/err_altern.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifdef TGL_AVOID_OPENSSL
 

--- a/crypto/err_openssl.c
+++ b/crypto/err_openssl.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifndef TGL_AVOID_OPENSSL
 

--- a/crypto/md5_altern.c
+++ b/crypto/md5_altern.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifdef TGL_AVOID_OPENSSL
 

--- a/crypto/md5_openssl.c
+++ b/crypto/md5_openssl.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifndef TGL_AVOID_OPENSSL
 

--- a/crypto/rand_altern.c
+++ b/crypto/rand_altern.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifdef TGL_AVOID_OPENSSL
 

--- a/crypto/rand_openssl.c
+++ b/crypto/rand_openssl.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifndef TGL_AVOID_OPENSSL
 

--- a/crypto/rsa_pem_altern.c
+++ b/crypto/rsa_pem_altern.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifdef TGL_AVOID_OPENSSL
 

--- a/crypto/rsa_pem_openssl.c
+++ b/crypto/rsa_pem_openssl.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifndef TGL_AVOID_OPENSSL
 

--- a/crypto/sha_altern.c
+++ b/crypto/sha_altern.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifdef TGL_AVOID_OPENSSL
 

--- a/crypto/sha_openssl.c
+++ b/crypto/sha_openssl.c
@@ -18,7 +18,7 @@
     Copyright Ben Wiederhake 2015
 */
 
-#include "../config.h"
+#include "config.h"
 
 #ifndef TGL_AVOID_OPENSSL
 


### PR DESCRIPTION
Don't use relative path to config.h, so that out-of source tree compiles works fine. (Main source directory is already included in -I compiler flags).