### PR TITLE
C++ compatibility fixes

### DIFF
--- a/scheme.tl
+++ b/scheme.tl
@@ -451,7 +451,7 @@ chatInviteEmpty#69df3769 = ExportedChatInvite;
 chatInviteExported#fc2e05bc link:string = ExportedChatInvite;
 
 chatInviteAlready#5a686d7c chat:Chat = ChatInvite;
-chatInvite#93e99b60 flags:# channel:flags.0?true broadcast:flags.1?true public:flags.2?true megagroup:flags.3?true title:string = ChatInvite;
+chatInvite#93e99b60 flags:# channel:flags.0?true broadcast:flags.1?true public_:flags.2?true megagroup:flags.3?true title:string = ChatInvite;
 
 inputStickerSetEmpty#ffb62b95 = InputStickerSet;
 inputStickerSetID#9de7a269 id:long access_hash:long = InputStickerSet;

--- a/tgl-queries.h
+++ b/tgl-queries.h
@@ -3,6 +3,10 @@
 
 #include "tgl.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void tgl_do_get_terms_of_service (struct tgl_state *TLS, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success, const char *ans), void *callback_extra);
 
 /* {{{ WORK WITH ACCOUNT */
@@ -121,7 +125,7 @@ void tgl_do_export_chat_link (struct tgl_state *TLS, tgl_peer_id_t id, void (*ca
 // joins to secret chat by link (or hash of this link)
 void tgl_do_import_chat_link (struct tgl_state *TLS, const char *link, int link_len, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success), void *callback_extra);
 
-// upgrades chat to channel. 
+// upgrades chat to channel.
 void tgl_do_upgrade_group (struct tgl_state *TLS, tgl_peer_id_t id, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success), void *callback_extra);
 /* }}} */
 
@@ -292,5 +296,9 @@ char *tglf_extf_fetch (struct tgl_state *TLS, struct paramed_type *T);
 /* {{{ BOT */
 void tgl_do_start_bot (struct tgl_state *TLS, tgl_peer_id_t bot, tgl_peer_id_t chat, const char *str, int str_len, void (*callback)(struct tgl_state *TLS, void *callback_extra, int success), void *callback_extra);
 /* }}} */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/tgl.h
+++ b/tgl.h
@@ -210,7 +210,7 @@ struct tgl_state {
   long long rsa_key_fingerprint[TGL_MAX_RSA_KEYS_NUM];
   int rsa_key_num;
 
-  TGLC_bn_ctx *TGLC_bn_ctx;
+  struct TGLC_bn_ctx *TGLC_bn_ctx;
 
   struct tgl_allocator *allocator;
 
@@ -386,6 +386,7 @@ void tgl_disable_link_preview (struct tgl_state *TLS);
 void tgl_do_lookup_state (struct tgl_state *TLS);
 
 long long tgl_get_allocated_bytes (void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This request includes some C++ compatibility fixes, including changing a .tl file which renames a field named 'public' to 'public_'. I'm not sure about a good name, so it can be changed to something better. 'public' is not allowed in C++.