### PR TITLE
OpenSSL 1.1 compatibility

### DIFF
--- a/crypto/rsa_pem_openssl.c
+++ b/crypto/rsa_pem_openssl.c
@@ -31,6 +31,47 @@
 #include "meta.h"
 #include "rsa_pem.h"
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
+{
+   /* If the fields n and e in r are NULL, the corresponding input
+    * parameters MUST be non-NULL for n and e.  d may be
+    * left NULL (in case only the public key is used).
+    */
+   if ((r->n == NULL && n == NULL)
+       || (r->e == NULL && e == NULL))
+       return 0;
+
+   if (n != NULL) {
+       BN_free(r->n);
+       r->n = n;
+   }
+   if (e != NULL) {
+       BN_free(r->e);
+       r->e = e;
+   }
+   if (d != NULL) {
+       BN_free(r->d);
+       r->d = d;
+   }
+
+   return 1;
+}
+
+void RSA_get0_key(const RSA *r,
+		  const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
+{
+  if (n != NULL)
+    *n = r->n;
+  if (e != NULL)
+    *e = r->e;
+  if (d != NULL)
+    *d = r->d;
+}
+
+#endif
+
 TGLC_WRAPPER_ASSOC(rsa,RSA)
 
 // TODO: Refactor crucial struct-identity into its own header.
@@ -38,19 +79,23 @@ TGLC_WRAPPER_ASSOC(bn,BIGNUM)
 
 TGLC_rsa *TGLC_rsa_new (unsigned long e, int n_bytes, const unsigned char *n) {
   RSA *ret = RSA_new ();
-  ret->e = unwrap_bn (TGLC_bn_new ());
-  TGLC_bn_set_word (wrap_bn (ret->e), e);
-  ret->n = unwrap_bn (TGLC_bn_bin2bn (n, n_bytes, NULL));
+  TGLC_bn* e_tglcbn = TGLC_bn_new ();
+  TGLC_bn_set_word (e_tglcbn, e);
+  RSA_set0_key(ret, unwrap_bn (TGLC_bn_bin2bn (n, n_bytes, NULL)), unwrap_bn(e_tglcbn), NULL); 
   return wrap_rsa (ret);
 }
 
-#define RSA_GETTER(M)                                                          \
-  TGLC_bn *TGLC_rsa_ ## M (TGLC_rsa *key) {                                    \
-    return wrap_bn (unwrap_rsa (key)->M);                                      \
-  }                                                                            \
+TGLC_bn *TGLC_rsa_n (TGLC_rsa * key) {
+  const BIGNUM *n;
+  RSA_get0_key( unwrap_rsa(key),  &n, NULL, NULL);
+  return wrap_bn(n);		
+}
 
-RSA_GETTER(n);
-RSA_GETTER(e);
+TGLC_bn *TGLC_rsa_e (TGLC_rsa * key) {
+  const BIGNUM *e;
+  RSA_get0_key( unwrap_rsa(key),  NULL, &e, NULL);
+  return wrap_bn(e);		
+}
 
 void TGLC_rsa_free (TGLC_rsa *p) {
   RSA_free (unwrap_rsa (p));


### PR DESCRIPTION
Resolves tg issue [#1248](https://github.com/vysheng/tg/issues/1248) / #1256 by accessing opaque structures as advised in [https://wiki.openssl.org/index.php/1.1_API_Changes](https://wiki.openssl.org/index.php/1.1_API_Changes) 