### PR TITLE
update queries.c

### DIFF
--- a/queries.c
+++ b/queries.c
@@ -1863,7 +1863,6 @@ static void send_avatar_end (struct tgl_state *TLS, struct send_file *f, void *c
     break;
   case TGL_PEER_USER:
     out_int (CODE_photos_upload_profile_photo);
-    out_int (CODE_photos_upload_profile_photo);
     break;
   case TGL_PEER_CHANNEL:
     out_int (CODE_channels_edit_photo);


### PR DESCRIPTION
removed duplicated line 1865 "out_int (CODE_photos_upload_profile_photo);" which prevented the upload of contact photo.