### PR TITLE
queries: fix partially-uninitialized struct

### DIFF
--- a/queries.c
+++ b/queries.c
@@ -2183,8 +2183,7 @@ void tgl_do_send_document (struct tgl_state *TLS, tgl_peer_id_t to_id, const cha
       flags |= TGLDF_AUDIO;
     }
   }
-  tgl_peer_id_t x;
-  x.peer_id = 0;
+  tgl_peer_id_t x = { .peer_id=0 };
   _tgl_do_send_photo (TLS, to_id, file_name, x, 100, 100, 100, 0, 0, caption, caption_len, flags, callback, callback_extra);
 }
 


### PR DESCRIPTION
The `x` instance wasn't initialized properly, which led to undefined
behaviour in _tgl_do_send_photo when copying its content to t->avatar.

This patch fixes that by using the C struct initializer syntax, which
implicitly sets all missing fields to 0.

Note that this UB triggers a compilation warning when compiling with
recent GCC versions in -O3.